### PR TITLE
qa: add helm chart tests and readme text

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -2,9 +2,6 @@
 name: Lint and Test Charts
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -1,2 +1,89 @@
 # s3gw-charts
-Helm charts for s3gw
+
+![GitHub](https://img.shields.io/github/license/aquarist-labs/s3gw-charts?style=for-the-badge)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/aquarist-labs/s3gw-charts/Lint%20and%20Test%20Charts?style=for-the-badge)
+
+Helm charts for [s3gw](https://github.com/aquarist-labs/s3gw-core)
+
+## Install
+
+In order to install s3gw using helm, from this repository directly, first you
+must clone the repo:
+
+    $ git clone https://github.com/aquarist-labs/s3gw-charts.git
+
+Before installing, familiarize yourself with the options, if necessary provide
+your own `values.yaml` file.
+Then change into the repository and install using helm:
+
+    $ cd s3gw-charts
+    $ helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE --create-namespace -f /path/to/your/custom/values.yaml
+
+## Options
+
+The helm chart can be customized for your Kubernetes environment. To do so,
+either provide a `values.yaml` file with your settings, or set the options on
+the command line directly using `helm --set key=value`.
+
+### Ingress Options
+
+Both NGinx and Traefik are supported as ingress controllers. If your cluster
+does not have either, it can be installed automatically by helm if
+`ingress.nginx.install` or `ingress.traefik.install` respectively is set to
+`true`
+If your cluster already has either one of the ingress controllers installed, you
+can enable the corresponding ingress object by setting `ingress.nginx.enabled`
+or `ingress.traefik.enabled` respectively to `true`.
+
+For example this configuration will reuse an existing traefik ingress controller
+by deploying a traefik ingress object:
+```yaml
+ingress:
+  nginx:
+    enabled: false
+    install: false
+  traefik:
+    enabled: true
+    install: false
+```
+
+### TLS Certificates
+
+provide the TLS certificate in the `values.yaml` file to enable TLS at the
+ingress.
+Note that the connection between the ingress and s3gw itself within the cluster 
+will not be TLS protected.
+
+```yaml
+tls:
+  crt: PUT_YOUR_CERTIFICATE_HERE
+  key: PUT_YOUR_CERTIFICATES_KEY_HERE
+```
+
+### Existing Volumes
+
+The s3gw is best deployed ontop of a [longhorn](https://longhorn.io) volume. If
+you have longhorn installed in your cluster, all appropriate resources will be
+automatically deployed for you.
+However if you want to use s3gw with other storage providers, you can do so too.
+You must first deploy a persistent volume claim for your storage provider. Then
+you deploy s3gw and set it to use that persistent volume claim (pvc) with:
+```yaml
+pvc: $NAME_OF_YOUR_PVC
+```
+s3gw will then reuse that pvc instead of deploying a longhorn volume.
+
+For testing, you can also use the special pvc name `local-storage`, it will
+deploy a pvc consuming a host-path in `/tmp/local-storage`
+
+### Image Settings
+
+In some cases, custom image settings are needed, e.g. in an air-gapped
+environment, or for developers. In that case, you can modify the registry and
+image settings:
+```yaml
+imageRegistry: "ghcr.io/aquarist-labs"
+imageName: "s3gw"
+imageTag: "latest"
+imagePullPolicy: "Always"
+```

--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: s3gw
-version: 0.1.0
+version: 0.1.1
 kubeVersion: ">=1.14"
 description: |
   Standalone S3-compatible gateway based on Ceph RGW using a non-RADOS storage

--- a/charts/s3gw/templates/tests/smoke-bucket-create.yaml
+++ b/charts/s3gw/templates/tests/smoke-bucket-create.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: 'smoke-{{ .Chart.Name }}-bucket-create'
+  namespace: '{{ .Release.Namespace }}'
+  annotations:
+    helm.sh/hook: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: create-bucket
+          image: opensuse/tumbleweed:latest
+          command:
+            - /bin/sh
+            - -exc
+            - zypper -n install --no-recommends libs3-tools;
+
+              s3 -u -t 50 create testbucket;
+
+              s3 -u -t 50 list | grep testbucket
+          env:
+            - name: S3_ACCESS_KEY_ID
+              value: {{ .Values.default.access_key | quote }}
+            - name: S3_SECRET_ACCESS_KEY
+              value: {{ .Values.default.secret_key | quote }}
+            - name: S3_HOSTNAME
+              value: 's3gw-svc.{{ .Release.Namespace }}.svc.cluster.local'
+      restartPolicy: Never
+  backoffLimit: 3


### PR DESCRIPTION
Add tests to the chart.

Helm tests are K8s jobs that Helm can utilize to determine if an
installation was successful. At the moment it is just a simple smoke
test, but in theory a full integration test can be implemented this way
as well.

Add some documentation to the readme. A short howto and explanation for
the options.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>