### PR TITLE
config: add default values for user settings

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -43,7 +43,9 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          ct lint --target-branch ${{ github.event.repository.default_branch }}
+          ct lint --target-branch \
+            ${{ github.event.repository.default_branch }} \
+            --check-version-increment=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: s3gw-config
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 data:
   RGW_BACKEND_STORE: "dbstore"
   DEBUG_RGW: "1"

--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -2,24 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  name: '{{ .Release.Name }}-dpl'
   namespace: {{ .Release.Namespace }}
   labels:
-    app.aquarist-labs.io/name: {{ .Chart.Name }}
-    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.aquarist-labs.io/name: {{ .Chart.Name }}
+{{ include "s3gw.selectorLabels" . | indent 6 }}
   strategy: {}
   template:
     metadata:
       labels:
-        app.aquarist-labs.io/name: {{ .Chart.Name }}
+{{ include "s3gw.labels" . | indent 8 }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/s3gw/templates/ingress-secret.yaml
+++ b/charts/s3gw/templates/ingress-secret.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: '{{ .Chart.Name }}-ingress-secret'
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 type: kubernetes.io/tls
 stringData:
   tls.crt: |

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -9,6 +9,8 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares:
       '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   ingressClassName: ingress-traefik
   tls:
@@ -36,6 +38,8 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares:
       '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   ingressClassName: ingress-traefik
   rules:
@@ -59,6 +63,8 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares:
       '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   ingressClassName: ingress-traefik
   tls:
@@ -84,6 +90,8 @@ kind: Middleware
 metadata:
   name: cors-header
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   headers:
     accessControlAllowMethods:

--- a/charts/s3gw/templates/local-storage.yaml
+++ b/charts/s3gw/templates/local-storage.yaml
@@ -5,6 +5,8 @@ kind: StorageClass
 metadata:
   name: local-storage
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 ---
@@ -13,6 +15,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: '{{ .Release.Name }}-local-pvc'
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   storageClassName: local-storage
   accessModes:
@@ -27,6 +31,7 @@ metadata:
   name: '{{ .Release.Name }}.{{ .Release.Namespace }}-local-pv'
   labels:
     type: local
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   storageClassName: local-storage
   capacity:

--- a/charts/s3gw/templates/longhorn-storage.yaml
+++ b/charts/s3gw/templates/longhorn-storage.yaml
@@ -5,6 +5,8 @@ kind: StorageClass
 metadata:
   name: longhorn-single
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -20,6 +22,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: s3gw-pvc
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   storageClassName: longhorn-single
   accessModes:

--- a/charts/s3gw/templates/secret.yaml
+++ b/charts/s3gw/templates/secret.yaml
@@ -6,5 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
+  RGW_DEFAULT_USER_ID: {{ .Values.userID | quote }}
+  RGW_DEFAULT_USER_DISPLAY_NAME: {{ .Values.userDisplayName | quote }}
+  RGW_DEFAULT_USER_EMAIL: {{ .Values.userEmail | quote }}
+  RGW_DEFAULT_USER_CAPS: {{ .Values.userCapabilities | quote }}
+  RGW_DEFAULT_USER_SYSTEM: "1"
+  RGW_DEFAULT_USER_ASSUMED_ROLE_ARN: ""
   RGW_DEFAULT_USER_ACCESS_KEY: {{ .Values.access_key | quote }}
   RGW_DEFAULT_USER_SECRET_KEY: {{ .Values.secret_key | quote }}

--- a/charts/s3gw/templates/secret.yaml
+++ b/charts/s3gw/templates/secret.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: '{{ .Chart.Name }}-secret'
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 type: Opaque
 stringData:
   RGW_DEFAULT_USER_ID: {{ .Values.userID | quote }}
@@ -12,5 +14,5 @@ stringData:
   RGW_DEFAULT_USER_CAPS: {{ .Values.userCapabilities | quote }}
   RGW_DEFAULT_USER_SYSTEM: "1"
   RGW_DEFAULT_USER_ASSUMED_ROLE_ARN: ""
-  RGW_DEFAULT_USER_ACCESS_KEY: {{ .Values.access_key | quote }}
-  RGW_DEFAULT_USER_SECRET_KEY: {{ .Values.secret_key | quote }}
+  RGW_DEFAULT_USER_ACCESS_KEY: {{ .Values.accessKey | quote }}
+  RGW_DEFAULT_USER_SECRET_KEY: {{ .Values.secretKey | quote }}

--- a/charts/s3gw/templates/service.yaml
+++ b/charts/s3gw/templates/service.yaml
@@ -2,8 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: '{{ .Chart.Name }}-svc'
+  name: '{{ .Release.Name }}-svc'
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4 }}
 spec:
   selector:
     app.aquarist-labs.io/name: {{ .Chart.Name }}

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -1,7 +1,11 @@
 ---
 # Default access credemtials:
-access_key: "0555b35654ad1656d804"
-secret_key: "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=="
+userID: "testid"
+userDisplayName: "M. Tester"
+userEmail: "tester@ceph.com"
+userCapabilities: "usage=read,write;users=read,write"
+accessKey: "0555b35654ad1656d804"
+secretKey: "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=="
 
 # S3 user interface
 ui:


### PR DESCRIPTION
Completely fill out the settings for the default user with values from
values.yaml, with the exception of RGW_DEFAULT_USER_SYSTEM and
RGW_DEFAULT_USER_ASSUMED_ROLE_ARN.
By default the initial user will be a system user with no role ARN. All
other values are taken from the values.yaml, including
RGW_DEFAULT_USER_CAPS, which are the default capabilities within the
admin API, which are initialized such that all capabilities are granted.
The default for the admin API entrypoint is not changed, meaning that it
will be `/admin/...`

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>