### PR TITLE
Remove Traefik Dependency from chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2022-07-14
+
+### Added
+
+- Everything

--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ Helm charts for [s3gw](https://github.com/aquarist-labs/s3gw-core)
 In order to install s3gw using helm, from this repository directly, first you
 must clone the repo:
 
-    $ git clone https://github.com/aquarist-labs/s3gw-charts.git
+    git clone https://github.com/aquarist-labs/s3gw-charts.git
 
 Before installing, familiarize yourself with the options, if necessary provide
 your own `values.yaml` file.
 Then change into the repository and install using helm:
 
-    $ cd s3gw-charts
-    $ helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE --create-namespace -f /path/to/your/custom/values.yaml
+    cd s3gw-charts
+    helm install $RELEASE_NAME charts/s3gw --namespace $S3GW_NAMESPACE --create-namespace -f /path/to/your/custom/values.yaml
+
+## Dependencies
+
+### Traefik
+
+If you intend to install s3gw with an ingress resource, you must ensure your environment is
+equipped with a [Traefik](https://helm.traefik.io/traefik) ingress controller.
 
 ## Options
 
@@ -29,6 +36,7 @@ the command line directly using `helm --set key=value`.
 
 Use the `hostname` setting to configure the hostname under which you would like
 to make the gateway available:
+
 ```yaml
 hostname: s3gw.local
 ```
@@ -37,11 +45,9 @@ The plain HTTP endpoint will then be generated as: `no-tls-s3gw.local`
 
 ### Ingress Options
 
-The chart can install an ingress resource for a Traefik ingress controller, but
-it can also install the ingress controller itself, if so desired:
+The chart can install an ingress resource for a Traefik ingress controller:
 ```yaml
 enableIngress: true
-installIngress: false
 ```
 
 ### TLS Certificates
@@ -64,6 +70,7 @@ you have longhorn installed in your cluster, all appropriate resources will be
 automatically deployed for you.
 Make sure the `storageType` is set to `"longhorn"` and the correct size for the
 claim is set in `storageSize`:
+
 ```yaml
 storageType: "longhorn"
 storageSize: 10Gi
@@ -72,15 +79,18 @@ storageSize: 10Gi
 However if you want to use s3gw with other storage providers, you can do so too.
 You must first deploy a persistent volume claim for your storage provider. Then
 you deploy s3gw and set it to use that persistent volume claim (pvc) with:
+
 ```yaml
 storageType: "pvc"
 storage: the-name-of-the-pvc
 ```
+
 s3gw will then reuse that pvc instead of deploying a longhorn volume.
 
 You can also use local filesystem storage instead, by setting `storageType` to
 `"local"`, `storageSize` to the desired quota and `storage` to the path on the
 hosts filesystem, e.g:
+
 ```yaml
 storageType: "local"
 storageSize: 10Gi
@@ -92,6 +102,7 @@ storage: /mnt/extra-storage/
 In some cases, custom image settings are needed, e.g. in an air-gapped
 environment, or for developers. In that case, you can modify the registry and
 image settings:
+
 ```yaml
 imageRegistry: "ghcr.io/aquarist-labs"
 imageName: "s3gw"
@@ -104,6 +115,7 @@ imagePullPolicy_ui: "Always"
 ```
 
 To configure the image and registry for the user interface, use:
+
 ```yaml
 imageName_ui: "s3gw-ui"
 imageTag_ui: "latest"

--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: s3gw
-version: 0.1.5
+version: 0.1.6
 kubeVersion: ">=1.14"
 description: |
   Standalone S3-compatible gateway based on Ceph RGW using a non-RADOS storage
@@ -14,11 +14,6 @@ sources:
   - https://github.com/aquarist-labs/s3gw-charts
   - https://github.com/aquarist-labs/s3gw-core
   - https://github.com/aquarist-labs/ceph
-dependencies:
-  - name: traefik
-    version: 10.20.1
-    repository: https://helm.traefik.io/traefik
-    condition: installIngress
 maintainers:
   - name: m-ildefons  # Moritz Röhrich
     email: moritz.rohrich@suse.com

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -11,10 +11,8 @@ ui:
 hostname: s3gw.local
 
 # Ingress configuration.
-# 'enableIngress' will deploy an ingress resource to the cluster,
-# 'installIngress' will also deploy the ingress controller, if desired.
+# 'enableIngress' will deploy an ingress resource to the cluster.
 enableIngress: true
-installIngress: false
 
 # TLS Certificate
 tls:


### PR DESCRIPTION
- Traefik dependency has been removed
- Traefik installation option has been removed

Fixes: https://github.com/aquarist-labs/s3gw-charts/issues/12
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>