### PR TITLE
Add app-readme for Rancher & remove maintainers

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          ct lint --target-branch ${{ github.event.repository.default_branch }}
+          ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false
+          ct lint --target-branch ${{ github.event.repository.default_branch }} \
+            --validate-maintainers=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: s3gw
-version: 0.1.6
+version: 0.1.7
 kubeVersion: ">=1.14"
 description: |
   Standalone S3-compatible gateway based on Ceph RGW using a non-RADOS storage
@@ -10,17 +10,16 @@ type: application
 keywords:
   - storage
   - s3
+home:
+  - https://github.com/aquarist-labs/s3gw-core
 sources:
   - https://github.com/aquarist-labs/s3gw-charts
   - https://github.com/aquarist-labs/s3gw-core
   - https://github.com/aquarist-labs/ceph
 maintainers:
-  - name: m-ildefons  # Moritz Röhrich
-    email: moritz.rohrich@suse.com
-    url: https://github.com/m-ildefons
-  - name: giubacc  # Giuseppe Baccini
-    email: giuseppe.baccini@suse.com
-    url: https://github.com/giubacc
+  - name: s3gw maintainers
+    email: s3gw@suse.com
+    url: https://github.com/orgs/aquarist-labs/projects/5
 appVersion: "latest"
 deprecated: false
 annotations:

--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -4,14 +4,13 @@ name: s3gw
 version: 0.1.7
 kubeVersion: ">=1.14"
 description: |
-  Standalone S3-compatible gateway based on Ceph RGW using a non-RADOS storage
+  Easy-to-use Open Source and Cloud Native S3 service for use on Rancher's Kubernetes.
   backend.
 type: application
 keywords:
   - storage
   - s3
-home:
-  - https://github.com/aquarist-labs/s3gw-core
+home: https://github.com/aquarist-labs/s3gw-core
 sources:
   - https://github.com/aquarist-labs/s3gw-charts
   - https://github.com/aquarist-labs/s3gw-core

--- a/charts/s3gw/app-readme.md
+++ b/charts/s3gw/app-readme.md
@@ -1,0 +1,8 @@
+# s3gw
+s3gw is an easy-to-use Open Source and Cloud Native S3 service running on Rancher's Kubernetes.
+
+* It complements the Rancher portfolio by offering an S3 service for Longhorn volume backups, Harvester backups, Epinio backups and OPNI models.
+* It is deployed on a single pod, ideal for development, Edge, IoT and smaller on-prem deployments.
+* It leverages the feature-rich S3 gateway from Ceph but without the rest of the Ceph stack.
+
+[Chart documentation]((https://github.com/aquarist-labs/s3gw-charts/tree/main/charts/s3gw/README.md))


### PR DESCRIPTION
This PR

- Adds an `app-readme` file with some information on the s3gw project for Rancher. 
- It also temporarily removes the maintainers' list. We don't want to have individual email addresses listed & we're in the process of getting a dedicated SUSE email address. We'll add the email address once we have access to it.

This PR references #14

Signed-off-by: Jesus Herman-Marina <jherman@suse.com>