### PR TITLE
Use prefix to access the RGW API to fix a HTTPS/CORS issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 charts/**/Chart.lock
 charts/**/charts/*.tgz
 values.yaml
+/.idea/

--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -7,3 +7,6 @@ metadata:
 data:
   RGW_BACKEND_STORE: "sfs"
   DEBUG_RGW: "1"
+{{- if .Values.ui.enabled }}
+  RGW_SERVICE_URL: 'api'
+{{- end }}

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares:
-      '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+      '{{ .Release.Namespace }}-cors-header@kubernetescrd,{{ .Release.Namespace }}-strip-api-prefix@kubernetescrd'
 spec:
   tls:
     - hosts:
@@ -34,7 +34,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares:
-      '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+      '{{ .Release.Namespace }}-cors-header@kubernetescrd,{{ .Release.Namespace }}-strip-api-prefix@kubernetescrd'
 spec:
   rules:
     - host: 'no-tls-{{ .Values.hostname }}'
@@ -74,6 +74,13 @@ spec:
                 name: '{{ .Chart.Name }}-ui-svc'
                 port:
                   number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: '{{ .Chart.Name }}-svc'
+                port:
+                  number: 80
 ---
 # UI No TLS Ingress
 apiVersion: networking.k8s.io/v1
@@ -96,6 +103,25 @@ spec:
                 name: '{{ .Chart.Name }}-ui-svc'
                 port:
                   number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: '{{ .Chart.Name }}-svc'
+                port:
+                  number: 80
+---
+# Middleware for Traefik
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-api-prefix
+  namespace: {{ .Release.Namespace }}
+spec:
+  stripPrefix:
+    prefixes:
+      - /api
+    forceSlash: false
 {{- end }}
 ---
 # Middleware for Traefik


### PR DESCRIPTION
Fixes: https://github.com/aquarist-labs/s3gw/issues/31
Related to: https://github.com/aquarist-labs/s3gw-tools/pull/135

Signed-off-by: Volker Theile <vtheile@suse.com>