### PR TITLE
Configure UI and add information about CORS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 charts/**/Chart.lock
 charts/**/charts/*.tgz
 values.yaml
+/.idea/

--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -7,3 +7,6 @@ metadata:
 data:
   RGW_BACKEND_STORE: "sfs"
   DEBUG_RGW: "1"
+{{- if .Values.ui.enabled }}
+  RGW_SERVICE_URL: 'https://{{ .Values.hostname }}'
+{{- end }}

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -4,6 +4,15 @@ access_key: "test"
 secret_key: "test"
 
 # S3 user interface
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Note, the UI will not be able to access the RGW AdminOps API when
+# using HTTPS and self-signed certificates because of CORS issues.
+# To workaround that, please open the URL https://<HOSTNAME> in the
+# browser and accept the SSL certificate before accessing the UI
+# via https://ui-<HOSTNAME>.
+# Check https://github.com/aquarist-labs/s3gw/issues/31 to get more
+# information about the CORS issues.
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ui:
   enabled: false
 


### PR DESCRIPTION
- Configure UI to be able to access the S3GW RGW AdminOps API.
- Add hint how to workaround the CORS issue in the UI when using HTTPS and self-signed certificates.

Signed-off-by: Volker Theile <vtheile@suse.com>