### PR TITLE
linter: disable version check

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -43,7 +43,9 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          ct lint --target-branch ${{ github.event.repository.default_branch }} \
+          ct lint --target-branch \
+            ${{ github.event.repository.default_branch }} \
+            --check-version-increment=false \
             --validate-maintainers=false
 
       - name: Create kind cluster


### PR DESCRIPTION
Disable version checking by the linter for each PR.
This check is not necessary since we don't create a new chart release
after every PR.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>