### PR TITLE
ci: remove traefik installation from ci pipeline

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -56,8 +56,6 @@ jobs:
         run: |
           ct install --target-branch \
             ${{ github.event.repository.default_branch }} \
-            --chart-repos \
-            ingress-traefik=https://helm.traefik.io/traefik \
             --helm-extra-set-args="--set=storageType=local,storage=/tmp/local-storage,enableIngress=false" \
             --helm-extra-args="--timeout=500s" \
             --debug


### PR DESCRIPTION
Remove the traefik installation from the ci pipeline's install test
step. This is unnecessary since the chart no longer depends on traefik.
The ingress installation was never tested during this step, but the
installation of the traefik chart was still necessary since all
dependencies of a chart must be installed regardless of whether they are
used or not.

fixes: #68
Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>