### PR TITLE
Set 'system' flag for default user

### DIFF
--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -10,3 +10,4 @@ data:
 {{- if .Values.ui.enabled }}
   RGW_SERVICE_URL: 'https://{{ .Values.hostname }}'
 {{- end }}
+  RGW_DEFAULT_USER_SYSTEM: "1"


### PR DESCRIPTION
This flag will add more information to the response when a bucket is created. This information is needed by the UI to be able to link the new created bucket to the specified user.

Fixes: https://github.com/aquarist-labs/s3gw/issues/66

Signed-off-by: Volker Theile <vtheile@suse.com>