### PR TITLE
Various improvements.

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -56,6 +56,6 @@ jobs:
         run: |
           ct install --target-branch \
             ${{ github.event.repository.default_branch }} \
-            --helm-extra-set-args="--set=storageType=local,storage=/tmp/local-storage,enableIngress=false" \
+            --helm-extra-set-args="--set=storageType=local,storage=/tmp/local-storage,ingress.enabled=false" \
             --helm-extra-args="--timeout=500s" \
             --debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2022-09-XX
+
+### Added
+
+- The variables `hostnameNoTLS`, `ui.hostname` and `ui.hostnameNoTLS`
+  has been added to configure the hostnames of the S3GW and S3GW-UI.
+  
+### Changed
+
+- Defaulted `ui.enabled` to `true`.
+- Rename the `access_key` and `secret_key` variable names according
+  the Helm Chart best practices guide to `accessKey` and `secretKey`.
+- Rename the `enableIngress` variable to `ingress.enabled`.
+- Relocate the variables `imageRegistry_ui`, `imageName_ui`,
+  `imageTag_ui` and `imagePullPolicy_ui` to `ui.imageRegistry`,
+  `ui.imageName`, `ui.imageTag` and `ui.imagePullPolicy` 
+  
 ## [0.4.0] - 2022-09-01
 
 ### Added

--- a/charts/s3gw/README.md
+++ b/charts/s3gw/README.md
@@ -28,24 +28,33 @@ the command line directly using `helm --set key=value`.
 ### Hostname
 
 Use the `hostname` setting to configure the hostname under which you would like
-to make the gateway available:
+to make the gateway available via HTTPS. The `hostnameNoTLS` settings is the
+equivalent for HTTP connections.
 
 ```yaml
-hostname: s3gw.local
+hostname: "s3gw.local"
+hostnameNoTLS: "s3gw-no-tls.local"
 ```
 
-The plain HTTP endpoint will then be generated as: `no-tls-s3gw.local`
+Use the following settings to configure the user interface:
+
+```yaml
+ui:
+  hostname: "s3gw-ui.local"
+  hostnameNoTLS: "s3gw-ui-no-tls.local"
+```
 
 ### Ingress Options
 
 The chart can install an ingress resource for a Traefik ingress controller:
 ```yaml
-enableIngress: true
+ingress:
+  enabled: true
 ```
 
 ### TLS Certificates
 
-provide the TLS certificate in the `values.yaml` file to enable TLS at the
+Provide the TLS certificate in the `values.yaml` file to enable TLS at the
 ingress.
 Note that the connection between the ingress and s3gw itself within the cluster
 will not be TLS protected.
@@ -101,15 +110,9 @@ imageRegistry: "ghcr.io/aquarist-labs"
 imageName: "s3gw"
 imageTag: "latest"
 imagePullPolicy: "Always"
-imageRegistry_ui: "ghcr.io/aquarist-labs"
-imageName_ui: "s3gw-ui"
-imageTag_ui: "latest"
-imagePullPolicy_ui: "Always"
-```
-
-To configure the image and registry for the user interface, use:
-
-```yaml
-imageName_ui: "s3gw-ui"
-imageTag_ui: "latest"
+ui:
+  imageRegistry: "ghcr.io/aquarist-labs"
+  imageName: "s3gw-ui"
+  imageTag: "latest"
+  imagePullPolicy: "Always"
 ```

--- a/charts/s3gw/questions.yaml
+++ b/charts/s3gw/questions.yaml
@@ -1,14 +1,14 @@
 questions:
 # Default access credentials:
 
-- variable: access_key
+- variable: accessKey
   default: test
   description: "Access Key"
   label: "Access Key"
   required: true
   type: string
   group: "General"
-- variable: secret_key
+- variable: secretKey
   default: test
   description: "Secret Key"
   label: "Secret Key"
@@ -17,7 +17,7 @@ questions:
   group: "General"
 - variable: hostname
   default: s3gw.local
-  description: "DNS URL for the S3 Service"
+  description: "Hostname of the S3 Service"
   label: "hostname"
   required: true
   type: string
@@ -82,7 +82,7 @@ questions:
   group: "Storage"
 
 #Ingress
-- variable: enableIngress
+- variable: ingress.enabled
   default: true
   description: "Enable Ingress"
   label: "Enable Ingress"
@@ -117,28 +117,28 @@ questions:
   required: false
   type: string
   group: "Images"
-- variable: imageRegistry_ui
+- variable: ui.imageRegistry
   default: "ghcr.io/aquarist-labs"
   description: "UI Image Registry"
   label: "UI Image Registry"
   required: false
   type: string
   group: "Images"
-- variable: imagePullPolicy_ui
+- variable: ui.imagePullPolicy
   default: "Always"
   description: "UI Image Pull Policy"
   label: "UI Image Pull Policy"
   required: false
   type: string
   group: "Images"
-- variable: imageName_ui
+- variable: ui.imageName
   default: "s3gw-ui"
   description: "UI Image Name"
   label: "UI Image Name"
   required: false
   type: string
   group: "Images"
-- variable: imageTag_ui
+- variable: ui.imageTag
   default: "v0.3.0"
   description: "UI Image Tag"
   label: "UI Image Tag"

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.enableIngress }}
+{{ if .Values.ingress.enabled }}
 ---
 # TLS Ingress
 apiVersion: networking.k8s.io/v1
@@ -37,7 +37,7 @@ metadata:
       '{{ .Release.Namespace }}-cors-header@kubernetescrd'
 spec:
   rules:
-    - host: 'no-tls-{{ .Values.hostname }}'
+    - host: '{{ .Values.hostnameNoTLS }}'
       http:
         paths:
           - path: /
@@ -61,10 +61,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - 'ui-{{ .Values.hostname }}'
+        - '{{ .Values.ui.hostname }}'
       secretName: '{{ .Chart.Name }}-ingress-secret'
   rules:
-    - host: 'ui-{{ .Values.hostname }}'
+    - host: '{{ .Values.ui.hostname }}'
       http:
         paths:
           - path: /
@@ -86,7 +86,7 @@ metadata:
       '{{ .Release.Namespace }}-cors-header@kubernetescrd'
 spec:
   rules:
-    - host: 'no-tls-ui-{{ .Values.hostname }}'
+    - host: '{{ .Values.ui.hostnameNoTLS }}'
       http:
         paths:
           - path: /

--- a/charts/s3gw/templates/secret.yaml
+++ b/charts/s3gw/templates/secret.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  RGW_DEFAULT_USER_ACCESS_KEY: {{ .Values.access_key | quote }}
-  RGW_DEFAULT_USER_SECRET_KEY: {{ .Values.secret_key | quote }}
+  RGW_DEFAULT_USER_ACCESS_KEY: {{ .Values.accessKey | quote }}
+  RGW_DEFAULT_USER_SECRET_KEY: {{ .Values.secretKey | quote }}

--- a/charts/s3gw/templates/tests/smoke-bucket-create.yaml
+++ b/charts/s3gw/templates/tests/smoke-bucket-create.yaml
@@ -22,9 +22,9 @@ spec:
               s3 -u -t 50 list | grep testbucket
           env:
             - name: S3_ACCESS_KEY_ID
-              value: {{ .Values.access_key | quote }}
+              value: {{ .Values.accessKey | quote }}
             - name: S3_SECRET_ACCESS_KEY
-              value: {{ .Values.secret_key | quote }}
+              value: {{ .Values.secretKey | quote }}
             - name: S3_HOSTNAME
               value: 's3gw-svc.{{ .Release.Namespace }}.svc.cluster.local'
       restartPolicy: Never

--- a/charts/s3gw/templates/ui-deployment.yaml
+++ b/charts/s3gw/templates/ui-deployment.yaml
@@ -25,8 +25,8 @@ spec:
       containers:
         - name: s3gw-ui
           image:
-            '{{ .Values.imageRegistry_ui }}/{{ .Values.imageName_ui }}:{{ .Values.imageTag_ui }}'
-          imagePullPolicy: {{ .Values.imagePullPolicy_ui }}
+            '{{ .Values.ui.imageRegistry }}/{{ .Values.ui.imageName }}:{{ .Values.ui.imageTag }}'
+          imagePullPolicy: {{ .Values.ui.imagePullPolicy }}
           ports:
             - containerPort: 8080
           envFrom:

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -1,7 +1,7 @@
 ---
 # Default access credentials:
-access_key: "test"
-secret_key: "test"
+accessKey: "test"
+secretKey: "test"
 
 # S3 user interface
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -9,19 +9,33 @@ secret_key: "test"
 # using HTTPS and self-signed certificates because of CORS issues.
 # To workaround that, please open the URL https://<HOSTNAME> in the
 # browser and accept the SSL certificate before accessing the UI
-# via https://ui-<HOSTNAME>.
+# via https://<UI-HOSTNAME>.
 # Check https://github.com/aquarist-labs/s3gw/issues/31 to get more
 # information about the CORS issues.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ui:
-  enabled: false
+  # 'enabled' will deploy the S3GW user interface if set to `true`.
+  enabled: true
+  # 'hostname' is the hostname of the S3GW user interface accessible via HTTPS.
+  hostname: "s3gw-ui.local"
+  # 'hostnameNoTLS' is the hostname of the S3GW user interface accessible via HTTP.
+  hostnameNoTLS: "s3gw-ui-no-tls.local"
 
-# FQDN for the endpoint
-hostname: s3gw.local
+  # --- Developer Options ---
+  imageRegistry: "ghcr.io/aquarist-labs"
+  imagePullPolicy: "Always"
+  imageName: "s3gw-ui"
+  imageTag: "v0.4.0"
+
+# 'hostname' is the hostname of the S3GW accessible via HTTPS.
+hostname: "s3gw.local"
+# 'hostnameNoTLS' is the hostname of the S3GW accessible via HTTP.
+hostnameNoTLS: "s3gw-no-tls.local"
 
 # Ingress configuration.
-# 'enableIngress' will deploy an ingress resource to the cluster.
-enableIngress: true
+ingress:
+  # 'enabled' will deploy an ingress resource to the cluster if set to `true`.
+  enabled: true
 
 # TLS Certificate
 tls:
@@ -48,13 +62,5 @@ storageSize: 10Gi
 # Image settings:
 imageRegistry: "ghcr.io/aquarist-labs"
 imagePullPolicy: "Always"
-
 imageName: "s3gw"
 imageTag: "v0.4.0"
-
-# Image UI settings:
-imageRegistry_ui: "ghcr.io/aquarist-labs"
-imagePullPolicy_ui: "Always"
-
-imageName_ui: "s3gw-ui"
-imageTag_ui: "v0.4.0"


### PR DESCRIPTION
- Rename `enableIngress` to `ingress.enabled`.
- Introduce `hostnameNoTLS` values.
- Relocate xxxx_ui variables.
- Rename the `access_key` and `secret_key` variable names according the Helm Chart best practices guide to `accessKey` and `secretKey`.
- Defaulted `ui.enabled` to `true`.

Fixes: https://github.com/aquarist-labs/s3gw/issues/90

Signed-off-by: Volker Theile <vtheile@suse.com>