### PR TITLE
chart: fix links in chart description

### DIFF
--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -9,11 +9,11 @@ type: application
 keywords:
   - storage
   - s3
-home: https://github.com/aquarist-labs/s3gw-core
+home: https://github.com/aquarist-labs/s3gw
 icon: https://raw.githubusercontent.com/aquarist-labs/aquarium-website/gh-pages/images/logo-xl.png
 sources:
   - https://github.com/aquarist-labs/s3gw-charts
-  - https://github.com/aquarist-labs/s3gw-core
+  - https://github.com/aquarist-labs/s3gw
   - https://github.com/aquarist-labs/ceph
 maintainers:
   - name: s3gw maintainers


### PR DESCRIPTION
Fix deprecated links to s3gw-core (now s3gw-tools) in chart description.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
