### PR TITLE
release: v0.6.1

### DIFF
--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: s3gw
-version: 0.6.0
+version: 0.6.1
 kubeVersion: ">=1.14"
 description: |
   Easy-to-use Open Source and Cloud Native S3 service for use on Rancher's Kubernetes.


### PR DESCRIPTION
A bugfix release.
This release fixes the issue that the chart version v0.6.0 installs images with version v0.5.0.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
