### PR TITLE
fix: image pull secret in deployment

### DIFF
--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
 {{- if .Values.imageCredentials }}
       imagePullSecrets:
-        - {{ .Chart.Name }}-image-pull-secret
+        - name: {{ .Chart.Name }}-image-pull-secret
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -71,7 +71,7 @@ spec:
     spec:
 {{- if .Values.imageCredentials }}
       imagePullSecrets:
-        - {{ .Chart.Name }}-image-pull-secret
+        - name: {{ .Chart.Name }}-image-pull-secret
 {{- end }}
       containers:
         - name: s3gw-ui


### PR DESCRIPTION
Fix the way image pull secrets are referenced in the deployment to allow pulling images from private registries

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
