### PR TITLE
No access to ETag property on response. Check CORS configuration to expose ETag header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - unreleased
+
+### Changed
+
+- Expose `ETag` header in the Traefik s3gw ingress to allow multi-part
+  uploads via browser (gh#aquarist-labs/s3gw#170).
+
 ## [0.7.0] - 2022-10-20
 
 ### Changed

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -148,4 +148,6 @@ spec:
       - "*"
     accessControlAllowHeaders:
       - "*"
+    accessControlExposeHeaders:
+      - "ETag"
 {{- end }}


### PR DESCRIPTION
Fixes: https://github.com/aquarist-labs/s3gw/issues/170

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
