### PR TITLE
ingress: unify hostnames

### DIFF
--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -52,7 +52,7 @@ metadata:
       '{{ .Release.Namespace }}-cors-header@kubernetescrd'
 spec:
   rules:
-    - host: '{{ .Values.hostnameNoTLS }}'
+    - host: '{{ .Values.hostname }}'
       http:
         paths:
           - path: /
@@ -62,7 +62,7 @@ spec:
                 name: '{{ .Chart.Name }}-svc'
                 port:
                   number: 80
-    - host: '*.{{ .Values.hostnameNoTLS }}'
+    - host: '*.{{ .Values.hostname }}'
       http:
         paths:
           - path: /
@@ -116,7 +116,7 @@ metadata:
       '{{ .Release.Namespace }}-cors-header@kubernetescrd'
 spec:
   rules:
-    - host: '{{ .Values.ui.hostnameNoTLS }}'
+    - host: '{{ .Values.ui.hostname }}'
       http:
         paths:
           - path: /

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -18,8 +18,6 @@ ui:
   enabled: true
   # 'hostname' is the hostname of the S3GW user interface accessible via HTTPS.
   hostname: "s3gw-ui.local"
-  # 'hostnameNoTLS' is the hostname of the S3GW user interface accessible via HTTP.
-  hostnameNoTLS: "s3gw-ui-no-tls.local"
 
   # TLS certificate and key
   # Base64 encoded in one line. The CN must match .ui.hostname
@@ -32,8 +30,6 @@ ui:
 
 # 'hostname' is the hostname of the S3GW accessible via HTTPS.
 hostname: "s3gw.local"
-# 'hostnameNoTLS' is the hostname of the S3GW accessible via HTTP.
-hostnameNoTLS: "s3gw-no-tls.local"
 
 # Ingress configuration.
 ingress:


### PR DESCRIPTION
Unify hostnames for TLS/non-TLS traffic. Theses two types of traffic will be separated by different ports.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
