### PR TITLE
Add wildcard host to tls section.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning][2].
 - Expose `ETag` header in the Traefik s3gw ingress to allow multi-part
   uploads via browser (gh#aquarist-labs/s3gw#170).
 - Add the `OPTIONS` method to the Traefik CORS configuration (gh#aquarist-labs/s3gw#188).
+- Fix an issue in the GW ingress related to TLS + wildcard host.
 
 ## [0.7.0] - 2022-10-20
 

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -16,6 +16,7 @@ spec:
   tls:
     - hosts:
         - '{{ .Values.hostname }}'
+        - '*.{{ .Values.hostname }}'
       secretName: 'certificates-{{ .Values.hostname }}'
   rules:
     - host: '{{ .Values.hostname }}'


### PR DESCRIPTION
Guessing the TLS certificate fails without explicitly configuring the wildcard host in the TLS section.

Before:
![Bildschirmfoto vom 2022-11-04 13-24-42](https://user-images.githubusercontent.com/1897962/199972179-0b8fa387-45f8-4377-8c11-d4af101c8984.png)

After:
![Bildschirmfoto vom 2022-11-04 13-24-19](https://user-images.githubusercontent.com/1897962/199972340-c8d444e0-a11a-42a4-b060-f6ccaebd856d.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
