### PR TITLE
ci: add manual release workflow trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Lint, Test and Release
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   lint-and-test:
@@ -64,7 +65,7 @@ jobs:
 
   # If a push to main happens (i.e. when merging PRs), release the chart.
   release:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || github.event_name = 'workflow_dispatch' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add manual trigger to release workflow to be able to force a release of the chart

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
