### PR TITLE
ci: disassemble chart release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,10 @@
 name: Lint, Test and Release
 
 on:
-  workflow_call:
+  push:
+    tags:
+      - "v*"
+
   workflow_dispatch:
 
 jobs:
@@ -63,9 +66,7 @@ jobs:
             --helm-extra-args="--timeout=500s" \
             --debug
 
-  # If a push to main happens (i.e. when merging PRs), release the chart.
   release:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -84,13 +85,36 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
           version: v3.10.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          docker run --rm \
+            -v ${GITHUB_WORKSPACE}:/chart \
+            -e CR_TOKEN=${CR_TOKEN} \
+            quay.io/helmpack/chart-releaser \
+            -- package s3gw \
+                  --package-path .cr-release-packages
+
+          docker run --rm \
+            -v ${GITHUB_WORKSPACE}:/chart \
+            -e CR_TOKEN=${CR_TOKEN} \
+            quay.io/helmpack/chart-releaser \
+            -- upload \
+                  -o "${{ env.GITHUB_REPOSITORY_OWNER }}" \
+                  -r s3gw-charts \
+                  -c "$(git rev-parse HEAD)"
+
+          docker run --rm \
+            -v ${GITHUB_WORKSPACE}:/chart \
+            -e CR_TOKEN=${CR_TOKEN} \
+            quay.io/helmpack/chart-releaser \
+            -- index \
+                  -o "${{ env.GITHUB_REPOSITORY_OWNER }}" \
+                  -r s3gw-charts \
+                  --push


### PR DESCRIPTION
- Disassemble chart release action into its subcommands.

This allows for greater control over the release process and is a prerequisite to fixing the automation.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
