### PR TITLE
TLS endpoint on internal s3gw pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,21 @@ and this project adheres to [Semantic Versioning][2].
     - `tls.ui.publicDomain.key`
   - The user can choose a custom `ClusterIssuer` by setting the following chart fields:
     - `useCustomTlsIssuer` and `customTlsIssuer`
+- **Internal TLS endpoint for the S3 service**
+  - The `s3gw`-Pod can now accept TLS connections on port `7481`.
+  - The `s3gw-cluster-ip-tls` secret is used to configure both
+    `ssl_certificate` and `ssl_private_key`.
+  - The `s3gw`-ClusterIP-Service has been extended to link the `s3gw`-Pod port
+    `7481` with the `s3gw`-ClusterIP-Service port `443`.
 
 ### Removed
 
 - Configuration options superseded by the newly added variables:
   - `tls.crt`, `tls.key`
   - `ui.tls.crt`, `ui.tls.key`
+- Dropped some entries from `s3gw-config` map:
+  - `RGW_DNS_NAME`, `RGW_BACKEND_STORE`, `DEBUG_RGW`
+  - when applicable, these values are now taken directly from the chart.
 
 ## [0.9.0] - 2022-12-01
 

--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -7,16 +7,6 @@ metadata:
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 data:
-{{- if .Values.ingress.enabled }}
-  RGW_DNS_NAME: >-
-    {{ .Values.serviceName }}.{{ .Values.publicDomain }},
-    {{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
-{{- else}}
-  RGW_DNS_NAME: >-
-    {{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
-{{- end }}
-  RGW_BACKEND_STORE: "sfs"
-  DEBUG_RGW: '{{ .Values.logLevel }}'
 {{- if .Values.ui.enabled }}
   RGW_SERVICE_URL: 'https://{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
 {{- end }}

--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -27,26 +27,41 @@ spec:
           imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy }}
           args:
             - "--rgw-dns-name"
-            - $(RGW_DNS_NAME)
+{{- if .Values.ingress.enabled }}
+            - {{ .Values.serviceName }}.{{ .Values.publicDomain }},
+              {{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
+{{- else}}
+            - {{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
+{{- end }}
             - "--rgw-backend-store"
-            - $(RGW_BACKEND_STORE)
+            - sfs
             - "--debug-rgw"
-            - $(DEBUG_RGW)
+            - '{{ .Values.logLevel }}'
+            - "--rgw_frontends"
+            - "beast port=7480 ssl_port=7481
+                ssl_certificate=/s3gw-cluster-ip-tls/tls.crt
+                ssl_private_key=/s3gw-cluster-ip-tls/tls.key"
           ports:
             - containerPort: 7480
               name: s3
+            - containerPort: 7481
+              name: s3-tls
           envFrom:
-            - configMapRef:
-                name: s3gw-config
             - secretRef:
                 name: s3gw-secret
           volumeMounts:
             - name: s3gw-lh-store
               mountPath: /data
+            - name: s3gw-cluster-ip-tls
+              mountPath: /s3gw-cluster-ip-tls
       volumes:
         - name: s3gw-lh-store
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-pvc
+        - name: s3gw-cluster-ip-tls
+          secret:
+            secretName: s3gw-cluster-ip-tls
+            optional: false
 {{- if .Values.ui.enabled }}
 ---
 apiVersion: apps/v1

--- a/charts/s3gw/templates/service.yaml
+++ b/charts/s3gw/templates/service.yaml
@@ -14,6 +14,10 @@ spec:
       protocol: TCP
       port: 80
       targetPort: s3
+    - name: s3-tls
+      protocol: TCP
+      port: 443
+      targetPort: s3-tls
 {{- if .Values.ui.enabled }}
 ---
 apiVersion: v1


### PR DESCRIPTION
# Describe your changes

Note: developed on top of [cert-manager PR](https://github.com/aquarist-labs/s3gw-charts/pull/65)

- Internal TLS endpoint for the S3 service
    - Configured the `s3gw` pod to accept TLS connections on port `7481`.
      TLS Certificate and Key are mounted on pod's filesystem with a volume
      from the `s3gw-cluster-ip-tls` secret.
    - The `s3gw` ClusterIP service has been extended to link the s3gw pod port
      `7481` with the service port `443`.
  
- Dropped some entries from `s3gw-config` map:
    - `RGW_DNS_NAME`, `RGW_BACKEND_STORE`, `DEBUG_RGW`
    - when applicable, these values are now taken directly from the chart.

## Issue ticket number and link

Fixes: https://github.com/aquarist-labs/s3gw/issues/232

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
