### PR TITLE
registry: move to quay

### DIFF
--- a/charts/s3gw/templates/_helpers.tpl
+++ b/charts/s3gw/templates/_helpers.tpl
@@ -74,15 +74,15 @@ Version helpers for the image tag
 {{- define "s3gw.image" -}}
 {{- $defaulttag := printf "v%s" .Chart.Version }}
 {{- $tag := default $defaulttag .Values.imageTag }}
-{{- $name := default "aquarist-labs/s3gw" .Values.imageName }}
-{{- $registry := default "ghcr.io" .Values.imageRegistry }}
+{{- $name := default "s3gw/s3gw" .Values.imageName }}
+{{- $registry := default "quay.io" .Values.imageRegistry }}
 {{- printf "%s/%s:%s" $registry $name $tag }}
 {{- end }}
 
 {{- define "s3gw-ui.image" -}}
 {{- $tag := default (printf "v%s" .Chart.Version) .Values.ui.imageTag }}
-{{- $name := default "aquarist-labs/s3gw-ui" .Values.ui.imageName }}
-{{- $registry := default "ghcr.io" .Values.imageRegistry }}
+{{- $name := default "s3gw/s3gw-ui" .Values.ui.imageName }}
+{{- $registry := default "quay.io" .Values.imageRegistry }}
 {{- printf "%s/%s:%s" $registry $name $tag }}
 {{- end }}
 

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -63,9 +63,9 @@ storageClass:
 # --- Developer Options ---
 #
 # Image settings:
-# imageRegistry: "ghcr.io"
+# imageRegistry: "quay.io"
 # imagePullPolicy: "Always"
-# imageName: "aquarist-labs/s3gw"
+# imageName: "s3gw/s3gw"
 # imageTag: "v0.0.0"
 # imageCredentials:
 #   username: foo


### PR DESCRIPTION
Change the source of the container images to quay.io/s3gw

Related: https://github.com/aquarist-labs/s3gw/issues/176

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
