### PR TITLE
ci: fix releae workflow trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Lint, Test and Release
 
 on:
   push:
-    branch:
+    branches:
       - "v*"
 
   workflow_dispatch:


### PR DESCRIPTION
Fix workflow definition syntax and only trigger on branches named 'v*'.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
