### PR TITLE
fix: add labels to certificate manager resources

### DIFF
--- a/charts/s3gw/templates/certificate.yaml
+++ b/charts/s3gw/templates/certificate.yaml
@@ -6,6 +6,8 @@ kind: Certificate
 metadata:
   name: s3gw-ca-cert
   namespace: {{ .Values.certManagerNamespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4}}
 spec:
   commonName: s3gw-ca
   isCA: true
@@ -23,6 +25,8 @@ kind: Certificate
 metadata:
   name: s3gw-cluster-ip-cert
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "s3gw.labels" . | indent 4}}
 spec:
   dnsNames:
     - '{{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'

--- a/charts/s3gw/templates/tls-issuer.yaml
+++ b/charts/s3gw/templates/tls-issuer.yaml
@@ -5,6 +5,8 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: s3gw-self-signed-issuer
+  labels:
+{{ include "s3gw.labels" . | indent 4}}
 spec:
   selfSigned: {}
 ---
@@ -13,6 +15,8 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: s3gw-issuer
+  labels:
+{{ include "s3gw.labels" . | indent 4}}
 spec:
   ca:
     secretName: s3gw-ca-root
@@ -22,6 +26,8 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: s3gw-letsencrypt-issuer
+  labels:
+{{ include "s3gw.labels" . | indent 4}}
 spec:
   acme:
     email: {{ .Values.email }}


### PR DESCRIPTION
Add missing labels to certificate management resources. This allows for clean upgrades and deinstallation when the chart has changed significantly or resources are moved between files between releases.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
