### PR TITLE
ci: fix base ref for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,16 +34,15 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch \
-            ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch ${GITHUB_REF_NAME})
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
         run: |
-          ct lint --target-branch \
-            ${{ github.event.repository.default_branch }} \
+          ct lint \
+            --target-branch ${GITHUB_REF_NAME} \
             --validate-maintainers=false
 
       - name: Create kind cluster
@@ -60,15 +59,13 @@ jobs:
           export CONFIG="$CONFIG,ingress.enabled=false"
           export CONFIG="$CONFIG,ui.enabled=false"
 
-          ct install --target-branch \
-            ${{ github.event.repository.default_branch }} \
+          ct install \
+            --target-branch ${GITHUB_REF_NAME} \
             --helm-extra-set-args="--set=${CONFIG}" \
             --helm-extra-args="--timeout=500s" \
             --debug
 
-  # If a push to main happens (i.e. when merging PRs), release the chart.
   release:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Change the base ref during version comparison of the release workflow. This allows changes to happen on main first and then be picked to a release branch without the linting step failing in the release pipeline.

Otherwise version bumps would need to happend first on the release branch and the be picked to the main branch, which is error prone and can get out of sync or be forgotten.

This way all changes happen on the main branch, then the relevant changes are picked to the release branch. The pipeline then compares the version in the Chart.yaml in whatever is pushed to the release branch to the version in the Chart.yaml at the previous HEAD of the release branch. If that version increased, the release pipeline will continue, thus avoiding accidental releases by pushing fixes to the release branch one-by-one.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
