### PR TITLE
S3 credentials for default user via existing secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
-## Unreleased
+## [0.11.0] - Unreleased
+
+### Added
+
+- Configuration options: `useExistingSecret` and `defaultUserCredentialsSecret`.
+  These fields allow the user to specify an existing secret containing
+  the S3 credentials for the default user.
+- `useExistingSecret` is a boolean field defaulted to false.
+- `defaultUserCredentialsSecret` is a string field denoting a `secret` in the `s3gw`
+  namespace. It must contain 2 keys:
+  - `RGW_DEFAULT_USER_ACCESS_KEY` that is the S3 Access Key for the default user.
+  - `RGW_DEFAULT_USER_SECRET_KEY` that is the S3 Secret Key for the default user.
+- When `useExistingSecret` is set to `false`, the chart will create
+  the secret using values from the preexisting fields `accessKey` and `secretKey`.
+- Setting `accessKey` or `secretKey` as the empty string, will force the Chart
+  to compute random alphanumeric values for the fields.
+- Defaulted values:
+  - `useExistingSecret`: false
+  - `defaultUserCredentialsSecret`: s3gw-creds
 
 ## [0.10.0] - 2022-12-22
 

--- a/charts/s3gw/questions.yaml
+++ b/charts/s3gw/questions.yaml
@@ -101,19 +101,39 @@ questions:
     type: string
     group: "General"
 
+  - variable: defaultUserCredentialsSecret
+    default: s3gw-creds
+    description: |
+      "The name of the secret containing the
+      S3 credentials for the default user"
+    type: string
+    group: "General"
+
+  - variable: useExistingSecret
+    default: false
+    description: |
+      "Check this to use a preexisting secret
+      containing the S3 credentials for the default user"
+    type: boolean
+    group: "General"
+
   - variable: accessKey
+    show_if: "useExistingSecret=false"
     default: test
-    description: "S3 Access Key"
+    description: |
+      "Set this as the empty string to make the Chart
+      to compute a random alphanumeric value"
     label: "S3 Access Key"
-    required: true
     type: string
     group: "General"
 
   - variable: secretKey
+    show_if: "useExistingSecret=false"
     default: test
-    description: "S3 Secret Key"
+    description: |
+      "Set this as the empty string to make the Chart
+      to compute a random alphanumeric value"
     label: "S3 Secret Key"
-    required: true
     type: string
     group: "General"
 

--- a/charts/s3gw/templates/NOTES.txt
+++ b/charts/s3gw/templates/NOTES.txt
@@ -1,0 +1,16 @@
+Thank you for installing {{ .Chart.Name }} {{ printf "v%s" .Chart.Version }}
+
+The S3 endpoint is available at:
+
+{{ printf "%s.%s" .Values.serviceName .Values.publicDomain | indent 4 }}
+{{ if .Values.ui.enabled}}
+and the web interface is available at:
+
+{{ printf "%s.%s" .Values.ui.serviceName .Values.ui.publicDomain | indent 4 }}
+{{- end }}
+{{ if and (not .Values.useExistingSecret) (empty .Values.accessKey) }}
+An access key has been generated: {{ include "s3gw.defaultAccessKey" . | quote }}
+{{- end }}
+{{- if and (not .Values.useExistingSecret) (empty .Values.secretKey) }}
+A secret key has been generated: {{ include "s3gw.defaultSecretKey" . | quote }}
+{{ end }}

--- a/charts/s3gw/templates/_helpers.tpl
+++ b/charts/s3gw/templates/_helpers.tpl
@@ -97,3 +97,16 @@ Image Pull Secret
 {{- $au := (printf "%s:%s" $un $pw | b64enc) }}
 {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" $rg $un $pw $em $au | b64enc}}
 {{- end }}
+
+
+{{/*
+Default Access Credentials
+*/}}
+{{- define "s3gw.defaultAccessKey" -}}
+{{- $key := default (randAlphaNum 32) .Values.accessKey }}
+{{- printf "%s" $key }}
+{{- end }}
+{{- define "s3gw.defaultSecretKey" -}}
+{{- $key := default (randAlphaNum 32) .Values.secretKey }}
+{{- printf "%s" $key }}
+{{- end }}

--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               name: s3-tls
           envFrom:
             - secretRef:
-                name: s3gw-secret
+                name: {{ .Values.defaultUserCredentialsSecret }}
           volumeMounts:
             - name: s3gw-lh-store
               mountPath: /data
@@ -96,5 +96,5 @@ spec:
             - configMapRef:
                 name: s3gw-config
             - secretRef:
-                name: s3gw-secret
+                name: {{ .Values.defaultUserCredentialsSecret }}
 {{- end }}

--- a/charts/s3gw/templates/secret.yaml
+++ b/charts/s3gw/templates/secret.yaml
@@ -1,15 +1,17 @@
+{{- if not .Values.useExistingSecret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ .Chart.Name }}-secret'
+  name: '{{ .Values.defaultUserCredentialsSecret }}'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
 type: Opaque
 stringData:
-  RGW_DEFAULT_USER_ACCESS_KEY: {{ .Values.accessKey | quote }}
-  RGW_DEFAULT_USER_SECRET_KEY: {{ .Values.secretKey | quote }}
+  RGW_DEFAULT_USER_ACCESS_KEY: {{ ternary (randAlphaNum 32) (.Values.accessKey) (empty .Values.accessKey) }}
+  RGW_DEFAULT_USER_SECRET_KEY: {{ ternary (randAlphaNum 32) (.Values.secretKey) (empty .Values.secretKey) }}
+{{- end }}
 {{- if .Values.imageCredentials }}
 ---
 apiVersion: v1

--- a/charts/s3gw/templates/secret.yaml
+++ b/charts/s3gw/templates/secret.yaml
@@ -9,8 +9,8 @@ metadata:
 {{ include "s3gw.labels" . | indent 4 }}
 type: Opaque
 stringData:
-  RGW_DEFAULT_USER_ACCESS_KEY: {{ ternary (randAlphaNum 32) (.Values.accessKey) (empty .Values.accessKey) }}
-  RGW_DEFAULT_USER_SECRET_KEY: {{ ternary (randAlphaNum 32) (.Values.secretKey) (empty .Values.secretKey) }}
+  RGW_DEFAULT_USER_ACCESS_KEY: {{ include "s3gw.defaultAccessKey" . | quote }}
+  RGW_DEFAULT_USER_SECRET_KEY: {{ include "s3gw.defaultSecretKey" . | quote }}
 {{- end }}
 {{- if .Values.imageCredentials }}
 ---

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -55,9 +55,17 @@ ui:
 #
 # 'serviceName' is the service name of S3GW.
 serviceName: "s3gw"
-# 'accessKey' is the S3 Access Key
+# 'useExistingSecret' use an existing secret containing the S3 credentials
+# for the default user
+useExistingSecret: false
+# 'defaultUserCredentialsSecret' the name of the secret containing
+# the S3 Access Key and the S3 Secret Key for the default user.
+defaultUserCredentialsSecret: "s3gw-creds"
+# 'accessKey' is the S3 Access Key; the value is used when useExistingSecret: false.
+# Set this as the empty string to make the Chart to compute a random alphanumeric value.
 accessKey: "test"
-# 'secretKey' is the S3 Secret Key
+# 'secretKey' is the S3 Secret Key; the value is used when useExistingSecret: false
+# Set this as the empty string to make the Chart to compute a random alphanumeric value.
 secretKey: "test"
 # 'publicDomain' is the public domain of S3GW used by the Ingress
 publicDomain: "be.127.0.0.1.omg.howdoi.website"


### PR DESCRIPTION
- Configuration options: `useExistingSecret` and `defaultUserCredentialsSecret`.
  These fields allow the user to specify an existing secret containing
  the S3 credentials for the default user.
- `useExistingSecret` is a boolean field defaulted to false.
- `defaultUserCredentialsSecret` is a string field denoting a `secret` in the `s3gw`
  namespace. It must contain 2 keys:
  - `RGW_DEFAULT_USER_ACCESS_KEY` that is the S3 Access Key for the default user.
  - `RGW_DEFAULT_USER_SECRET_KEY` that is the S3 Secret Key for the default user.
- When `useExistingSecret` is set to `false`, the chart will create
  the secret using values from the preexisting fields `accessKey` and `secretKey`.
- Setting `accessKey` or `secretKey` as the empty string, will force the Chart
  to compute random alphanumeric values for the fields.
- Defaulted values:
  - `useExistingSecret`: false
  - `defaultUserCredentialsSecret`: s3gw-creds

Tip: you can create a preexisting secret with a command like this:
 
```
kubectl create secret generic -n s3gw s3gw-creds --from-literal=accessKey=myaccesskey --from-literal=secretKey=supersecret
```

Fixes: https://github.com/aquarist-labs/s3gw/issues/303
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
