### PR TITLE
fix: upgrade redeploy strategy

### DIFF
--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -11,7 +11,8 @@ spec:
   selector:
     matchLabels:
 {{ include "s3gw.selectorLabels" . | indent 6 }}
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Specify the upgrade redeploy strategy, making sure it recreates the pods of the deployment rather than rolling out the upgrade. It is necessary to recreate the pods (i.e. delete the old pods and then create the new pods) rather than rolling out a new release (creating the new pods _before_ deleting the old pods), because the PVC is on ReadWriteOnce mode and thus the volume can only be claimed once by one pod.

fixes: aquarist-labs/s3gw#397

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
