### PR TITLE
feat: custom args and custom env-vars for radosgw process

### DIFF
--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -42,6 +42,21 @@ spec:
             - "beast port=7480 ssl_port=7481
                 ssl_certificate=/s3gw-cluster-ip-tls/tls.crt
                 ssl_private_key=/s3gw-cluster-ip-tls/tls.key"
+{{- range $.Values.rgwCustomArgs }}
+            - {{ . | quote}}
+{{- end }}
+          env:
+{{- range $.Values.rgwCustomEnvs }}
+{{- if (regexMatch "[^=]+=[^=]+" .) }}
+{{- $tokens := split "=" . }}
+            - name: {{ $tokens._0 }}
+              value: {{ $tokens._1 | quote}}
+{{- else if (regexMatch "^[^=]" .) }}
+            - name: {{ . }}
+{{- else }}
+{{- fail (print ".Values.rgwCustomEnvs contains an invalid entry: " .) }}
+{{- end }}
+{{- end }}
           ports:
             - containerPort: 7480
               name: s3

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -99,3 +99,43 @@ storageClass:
 # Valid values are positive integers starting from 0.
 # Higher values are more verbose.
 logLevel: "1"
+
+# --- Advanced Configuration ---
+
+# radosgw's custom arguments for the s3gw pod
+#
+# With 'helm install/update' you can specify custom arguments
+# for the radosgw process using the '--set' option:
+#
+# --set "rgwCustomArgs={--foo,bar,--color,green,--org,SUSE,--flag-param-foo}"
+#
+# The same effect could be obtained modifying rgwCustomArgs
+# directly in the values.yaml:
+#
+# rgwCustomArgs:
+#   - --foo
+#   - bar
+#   - --color
+#   - green
+#   - --org
+#   - SUSE
+#   - --flag-param-foo
+#
+rgwCustomArgs: []
+
+# radosgw's custom environment variables for the s3gw pod
+#
+# With 'helm install/update' you can specify custom environment variables
+# for the radosgw process using the '--set' option:
+#
+# --set "rgwCustomEnvs={ENV_1=ON,ENV_2=OFF,ENV_3}"
+#
+# The same effect could be obtained modifying rgwCustomEnvs
+# directly in the values.yaml:
+#
+# rgwCustomEnvs:
+#   - ENV_1=ON
+#   - ENV_2=OFF
+#   - ENV_3
+#
+rgwCustomEnvs: []


### PR DESCRIPTION
# Describe your changes

Added two array fields in values.yaml

  - `rgwCustomArgs`
  - `rgwCustomEnvs`

With `helm install/update` you can specify custom arguments for the radosgw process using the `--set` option

`--set "rgwCustomArgs={--foo,bar,--color,green,--org,SUSE,--flag-param-foo}"`

With `helm install/update` you can specify custom environment variables for the radosgw process using the `--set` option

`--set "rgwCustomEnvs={ENV_1=ON,ENV_2=OFF,ENV_3}"`

## Issue ticket number and link

Fixes: https://github.com/aquarist-labs/s3gw/issues/402

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
