### PR TITLE
The Traefik ingress is misconfigured, Access-Control-Expose-Headers must be set to '*'

### DIFF
--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -153,5 +153,5 @@ spec:
     accessControlAllowHeaders:
       - "*"
     accessControlExposeHeaders:
-      - "ETag"
+      - "*"
 {{- end }}


### PR DESCRIPTION
Fixes: https://github.com/aquarist-labs/s3gw/issues/410

The `accessControlExposeHeaders` property is set to `*` now to expose all headers by default. To fix the mentioned issue adding the `X-Amz-Object-Lock-Mode` and `X-Amz-Object-Lock-Retain-Until-Date` would be sufficient, but the problem might appear again in the future, but with a different header that is processed by the AWS SDK but is not exposed by the ingress.

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
