### PR TITLE
chart: add annotations for artifact hub

### DIFF
--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -4,13 +4,15 @@ name: s3gw
 version: 0.14.0
 kubeVersion: ">=1.14"
 description: |
-  Easy-to-use Open Source and Cloud Native S3 service for use on Rancher's Kubernetes.
+  Easy-to-use Open Source and Cloud Native S3 service for use on Rancher's
+  Kubernetes.
 type: application
 keywords:
   - storage
   - s3
 home: https://github.com/aquarist-labs/s3gw
-icon: https://raw.githubusercontent.com/aquarist-labs/aquarium-website/gh-pages/images/logo-xl.png
+icon: |-
+  https://raw.githubusercontent.com/aquarist-labs/aquarium-website/gh-pages/images/logo-xl.png
 sources:
   - https://github.com/aquarist-labs/s3gw-charts
   - https://github.com/aquarist-labs/s3gw
@@ -22,4 +24,10 @@ maintainers:
 appVersion: "latest"
 deprecated: false
 annotations:
+  artifacthub.io/category: storage
+  artifacthub.io/links: |
+    - name: homepage
+      url: https://s3gw.io/
+    - name: support
+      url: https://github.com/aquarist-labs/s3gw/issues
   app.aquarist-labs.io/name: s3gw


### PR DESCRIPTION
- Add annotations for artifact hub detailing links for the home page and where to get support, as well as tagging the chart with the `storage` tag.
- Break up long lines in `Chart.yaml`

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
