### PR TITLE
Fix http / no TLS configuration

### DIFF
--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -8,6 +8,10 @@ metadata:
 {{ include "s3gw.labels" . | indent 4}}
 data:
 {{- if .Values.ui.enabled }}
+{{- if or .Values.useCertManager .Values.tls.publicDomain.crt }}
   RGW_SERVICE_URL: 'https://{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+{{- else}}
+  RGW_SERVICE_URL: 'http://{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+{{- end }}
 {{- end }}
   RGW_DEFAULT_USER_SYSTEM: "1"

--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -39,9 +39,13 @@ spec:
             - "--debug-rgw"
             - '{{ .Values.logLevel }}'
             - "--rgw_frontends"
+{{- if or .Values.useCertManager .Values.tls.publicDomain.crt }}
             - "beast port=7480 ssl_port=7481
                 ssl_certificate=/s3gw-cluster-ip-tls/tls.crt
                 ssl_private_key=/s3gw-cluster-ip-tls/tls.key"
+{{ else }}
+            - "beast port=7480"
+{{ end }}
 {{- range $.Values.rgwCustomArgs }}
             - {{ . | quote}}
 {{- end }}
@@ -60,8 +64,10 @@ spec:
           ports:
             - containerPort: 7480
               name: s3
+{{- if or .Values.useCertManager .Values.tls.publicDomain.crt }}
             - containerPort: 7481
               name: s3-tls
+{{ end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.defaultUserCredentialsSecret }}


### PR DESCRIPTION
A no TLS / http configuration with
useCertManager = false and the TLS map not set

failed at two points:
- The UI's RGW_SERVICE_URL hard coded 'https'
- radosgw fails to start with invalid certificate config

Changes to support a http configuration:

ui.backendProtocol to control the protocol the UI speaks
with the S3GW backend.

No longer start a radosgw TLS frontend if neither cert manager, nor
the tls certificates are set up.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
