### PR TITLE
Ensure independent default installations

### DIFF
--- a/charts/s3gw/questions.yaml
+++ b/charts/s3gw/questions.yaml
@@ -73,7 +73,7 @@ questions:
 
   - variable: defaultUserCredentialsSecret
     show_if: useExistingSecret=true
-    default: s3gw-creds
+    default: ""
     description: |
       "The name of the secret containing the
       S3 credentials for the default user"

--- a/charts/s3gw/templates/NOTES.txt
+++ b/charts/s3gw/templates/NOTES.txt
@@ -2,11 +2,11 @@ Thank you for installing {{ .Chart.Name }} {{ printf "v%s" .Chart.Version }}
 
 The S3 endpoint is available at:
 
-{{ printf "%s.%s" .Values.serviceName .Values.publicDomain | indent 4 }}
+{{ printf "%s.%s" (include "s3gw.serviceName" .) .Values.publicDomain | indent 4 }}
 {{ if .Values.ui.enabled}}
 and the web interface is available at:
 
-{{ printf "%s.%s" .Values.ui.serviceName .Values.ui.publicDomain | indent 4 }}
+{{ printf "%s.%s" (include "s3gw.uiServiceName" .) .Values.ui.publicDomain | indent 4 }}
 {{- end }}
 {{ if and (not .Values.useExistingSecret) (empty .Values.accessKey) }}
 An access key has been generated: {{ include "s3gw.defaultAccessKey" . | quote }}

--- a/charts/s3gw/templates/_helpers.tpl
+++ b/charts/s3gw/templates/_helpers.tpl
@@ -110,3 +110,57 @@ Default Access Credentials
 {{- $key := default (randAlphaNum 32) .Values.secretKey }}
 {{- printf "%s" $key }}
 {{- end }}
+
+{{/*
+Default storage class name
+*/}}
+{{- define "s3gw.storageClassName" -}}
+{{- $dscn := printf "%s-%s-longhorn-single" .Release.Name .Release.Namespace }}
+{{- $name := default $dscn .Values.storageClass.name }}
+{{- $name }}
+{{- end }}
+
+{{/*
+Default backend service name
+*/}}
+{{- define "s3gw.serviceName" -}}
+{{- $dsn := printf "%s-%s" .Release.Name .Release.Namespace }}
+{{- $name := default $dsn .Values.serviceName }}
+{{- $name }}
+{{- end }}
+
+{{/*
+Default frontend service name
+*/}}
+{{- define "s3gw.uiServiceName" -}}
+{{- $dsn := printf "%s-%s-ui" .Release.Name .Release.Namespace }}
+{{- $name := default $dsn .Values.ui.serviceName }}
+{{- $name }}
+{{- end }}
+
+{{/*
+Default user credentials secret for S3 backend service
+*/}}
+{{- define "s3gw.defaultUserCredentialsSecret" -}}
+{{- $dsn := printf "%s-%s-creds" .Release.Name .Release.Namespace }}
+{{- $name := default $dsn .Values.defaultUserCredentialsSecret }}
+{{- $name }}
+{{- end }}
+
+{{/*
+Default config map name
+*/}}
+{{- define "s3gw.configMap" -}}
+{{- $dcmn := printf "%s-%s-config" .Release.Name .Release.Namespace }}
+{{- $name := $dcmn }}
+{{- $name }}
+{{- end }}
+
+{{/*
+Default Middleware CORS name
+*/}}
+{{- define "s3gw.CORSMiddlewareName" -}}
+{{- $dmcn := printf "%s-%s-cors-header" .Release.Name .Release.Namespace }}
+{{- $name := $dmcn }}
+{{- $name }}
+{{- end }}

--- a/charts/s3gw/templates/certificate.yaml
+++ b/charts/s3gw/templates/certificate.yaml
@@ -4,35 +4,35 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: s3gw-ca-cert
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-ca-cert
   namespace: {{ .Values.certManagerNamespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 spec:
-  commonName: s3gw-ca
+  commonName: {{ .Release.Name }}-{{ .Release.Namespace }}-ca
   isCA: true
   issuerRef:
     kind: ClusterIssuer
-    name: s3gw-self-signed-issuer
+    name: {{ .Release.Name }}-{{ .Release.Namespace }}-self-signed-issuer
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: s3gw-ca-root
+  secretName: {{ .Release.Name }}-{{ .Release.Namespace }}-ca-root
 ---
 # s3gw internal service certificate (private domain)
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: s3gw-cluster-ip-cert
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-cluster-ip-cert
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 spec:
   dnsNames:
-    - '{{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'
-    - '*.{{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'
+    - '{{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'
+    - '*.{{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'
   issuerRef:
     kind: ClusterIssuer
-    name: s3gw-issuer
-  secretName: s3gw-cluster-ip-tls
+    name: {{ .Release.Name }}-{{ .Release.Namespace }}-issuer
+  secretName: {{ .Release.Name }}-{{ .Release.Namespace }}-cluster-ip-tls
 {{- end }}

--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -2,15 +2,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: s3gw-config
+  name: {{ include "s3gw.configMap" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 data:
 {{- if .Values.ui.enabled }}
 {{- if or .Values.useCertManager .Values.tls.publicDomain.crt }}
-  RGW_SERVICE_URL: 'https://{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+  RGW_SERVICE_URL: 'https://{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
 {{- else}}
-  RGW_SERVICE_URL: 'http://{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+  RGW_SERVICE_URL: 'http://{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
 {{- end }}
 {{- end }}

--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
@@ -20,19 +20,19 @@ spec:
     spec:
 {{- if .Values.imageCredentials }}
       imagePullSecrets:
-        - name: {{ .Chart.Name }}-image-pull-secret
+        - name: {{ .Release.Name }}-image-pull-secret
 {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Release.Name }}
           image: {{ include "s3gw.image" . | quote }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy }}
           args:
             - "--rgw-dns-name"
 {{- if .Values.ingress.enabled }}
-            - {{ .Values.serviceName }}.{{ .Values.publicDomain }},
-              {{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
+            - {{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }},
+              {{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
 {{- else}}
-            - {{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
+            - {{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
 {{- end }}
             - "--rgw-backend-store"
             - sfs
@@ -70,7 +70,7 @@ spec:
 {{ end }}
           envFrom:
             - secretRef:
-                name: {{ .Values.defaultUserCredentialsSecret }}
+                name: {{ include "s3gw.defaultUserCredentialsSecret" . }}
           volumeMounts:
             - name: s3gw-lh-store
               mountPath: /data
@@ -82,14 +82,14 @@ spec:
             claimName: {{ .Release.Name }}-pvc
         - name: s3gw-cluster-ip-tls
           secret:
-            secretName: s3gw-cluster-ip-tls
+            secretName: {{ .Release.Name }}-{{ .Release.Namespace }}-cluster-ip-tls
             optional: false
 {{- if .Values.ui.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: '{{ .Chart.Name }}-ui'
+  name: '{{ .Release.Name }}-ui'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
@@ -106,7 +106,7 @@ spec:
     spec:
 {{- if .Values.imageCredentials }}
       imagePullSecrets:
-        - name: {{ .Chart.Name }}-image-pull-secret
+        - name: {{ .Release.Name }}-image-pull-secret
 {{- end }}
       containers:
         - name: s3gw-ui
@@ -116,7 +116,7 @@ spec:
             - containerPort: 8080
           envFrom:
             - configMapRef:
-                name: s3gw-config
+                name: {{ include "s3gw.configMap" . }}
             - secretRef:
-                name: {{ .Values.defaultUserCredentialsSecret }}
+                name: {{ include "s3gw.defaultUserCredentialsSecret" . }}
 {{- end }}

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -4,40 +4,40 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: '{{ .Chart.Name }}'
+  name: '{{ .Release.Name }}'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
   annotations:
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares:
-      '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+      '{{ .Release.Namespace }}-{{ include "s3gw.CORSMiddlewareName" . }}@kubernetescrd'
     cert-manager.io/cluster-issuer: {{ default .Values.tlsIssuer .Values.customTlsIssuer | quote }}
 spec:
   tls:
     - hosts:
-        - '{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
-        - '*.{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+        - '{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
+        - '*.{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
       secretName: s3gw-ingress-tls
   rules:
-    - host: '{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+    - host: '{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: '{{ .Values.serviceName }}'
+                name: '{{ include "s3gw.serviceName" . }}'
                 port:
                   number: 80
-    - host: '*.{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+    - host: '*.{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: '{{ .Values.serviceName }}'
+                name: '{{ include "s3gw.serviceName" . }}'
                 port:
                   number: 80
 ---
@@ -45,33 +45,33 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: '{{ .Chart.Name }}-no-tls'
+  name: '{{ .Release.Name }}-no-tls'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares:
-      '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+      '{{ .Release.Namespace }}-{{ include "s3gw.CORSMiddlewareName" . }}@kubernetescrd'
 spec:
   rules:
-    - host: '{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+    - host: '{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: '{{ .Values.serviceName }}'
+                name: '{{ include "s3gw.serviceName" . }}'
                 port:
                   number: 80
-    - host: '*.{{ .Values.serviceName }}.{{ .Values.publicDomain }}'
+    - host: '*.{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: '{{ .Values.serviceName }}'
+                name: '{{ include "s3gw.serviceName" . }}'
                 port:
                   number: 80
 {{- if .Values.ui.enabled }}
@@ -80,29 +80,29 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: '{{ .Chart.Name }}-ui'
+  name: '{{ .Release.Name }}-ui'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
   annotations:
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares:
-      '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+      '{{ .Release.Namespace }}-{{ include "s3gw.CORSMiddlewareName" . }}@kubernetescrd'
     cert-manager.io/cluster-issuer: {{ default .Values.tlsIssuer .Values.customTlsIssuer | quote }}
 spec:
   tls:
     - hosts:
-        - '{{ .Values.ui.serviceName }}.{{ .Values.ui.publicDomain }}'
+        - '{{ include "s3gw.uiServiceName" . }}.{{ .Values.ui.publicDomain }}'
       secretName: s3gw-ui-ingress-tls
   rules:
-    - host: '{{ .Values.ui.serviceName }}.{{ .Values.ui.publicDomain }}'
+    - host: '{{ include "s3gw.uiServiceName" . }}.{{ .Values.ui.publicDomain }}'
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: '{{ .Values.ui.serviceName }}'
+                name: '{{ include "s3gw.uiServiceName" . }}'
                 port:
                   number: 80
 ---
@@ -110,23 +110,23 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: '{{ .Chart.Name }}-ui-no-tls'
+  name: '{{ .Release.Name }}-ui-no-tls'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares:
-      '{{ .Release.Namespace }}-cors-header@kubernetescrd'
+      '{{ .Release.Namespace }}-{{ include "s3gw.CORSMiddlewareName" . }}@kubernetescrd'
 spec:
   rules:
-    - host: '{{ .Values.ui.serviceName }}.{{ .Values.ui.publicDomain }}'
+    - host: '{{ include "s3gw.uiServiceName" . }}.{{ .Values.ui.publicDomain }}'
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: '{{ .Values.ui.serviceName }}'
+                name: '{{ include "s3gw.uiServiceName" . }}'
                 port:
                   number: 80
 {{- end }}
@@ -135,7 +135,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  name: cors-header
+  name: {{ include "s3gw.CORSMiddlewareName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}

--- a/charts/s3gw/templates/secret.yaml
+++ b/charts/s3gw/templates/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ .Values.defaultUserCredentialsSecret }}'
+  name: {{ include "s3gw.defaultUserCredentialsSecret" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
@@ -17,7 +17,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ .Chart.Name }}-image-pull-secret'
+  name: '{{ .Release.Name }}-image-pull-secret'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}

--- a/charts/s3gw/templates/service.yaml
+++ b/charts/s3gw/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: '{{ .Values.serviceName }}'
+  name: '{{ include "s3gw.serviceName" . }}'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
@@ -23,7 +23,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: '{{ .Values.ui.serviceName }}'
+  name: '{{ include "s3gw.uiServiceName" . }}'
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}

--- a/charts/s3gw/templates/storage.yaml
+++ b/charts/s3gw/templates/storage.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
 spec:
-  storageClassName: {{ .Values.storageClass.name }}
+  storageClassName: {{ include "s3gw.storageClassName" . }}
   accessModes:
     - ReadWriteOnce
   resources:
@@ -18,8 +18,7 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Values.storageClass.name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "s3gw.storageClassName" . }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
 volumeBindingMode: Immediate
@@ -45,7 +44,7 @@ metadata:
 {{ include "s3gw.labels" . | indent 4 }}
     type: local
 spec:
-  storageClassName: {{ .Values.storageClass.name }}
+  storageClassName: {{ include "s3gw.storageClassName" . }}
   capacity:
     storage: {{ .Values.storageSize }}
   accessModes:

--- a/charts/s3gw/templates/tests/smoke-bucket-create.yaml
+++ b/charts/s3gw/templates/tests/smoke-bucket-create.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: 'smoke-{{ .Chart.Name }}-bucket-create'
+  name: 'smoke-{{ .Release.Name }}-bucket-create'
   namespace: '{{ .Release.Namespace }}'
   annotations:
     helm.sh/hook: test
@@ -27,6 +27,6 @@ spec:
               value: {{ .Values.secretKey | quote }}
             - name: S3_HOSTNAME
               value:
-                '{{ .Values.serviceName }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'
+                '{{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'
       restartPolicy: Never
   backoffLimit: 3

--- a/charts/s3gw/templates/tls-issuer.yaml
+++ b/charts/s3gw/templates/tls-issuer.yaml
@@ -4,7 +4,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: s3gw-self-signed-issuer
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-self-signed-issuer
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 spec:
@@ -14,18 +14,18 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: s3gw-issuer
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-issuer
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 spec:
   ca:
-    secretName: s3gw-ca-root
+    secretName: {{ .Release.Name }}-{{ .Release.Namespace }}-ca-root
 ---
 # Let's encrypt production issuer
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: s3gw-letsencrypt-issuer
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-letsencrypt-issuer
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 spec:
@@ -33,7 +33,7 @@ spec:
     email: {{ .Values.email }}
     preferredChain: ""
     privateKeySecretRef:
-      name: s3gw-letsencrypt
+      name: {{ .Release.Name }}-{{ .Release.Namespace }}-letsencrypt
     server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
     - http01:

--- a/charts/s3gw/templates/tls-secret.yaml
+++ b/charts/s3gw/templates/tls-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: s3gw-ingress-tls
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-ingress-tls
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
@@ -17,7 +17,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: s3gw-cluster-ip-tls
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-cluster-ip-tls
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
@@ -32,7 +32,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: s3gw-ui-ingress-tls
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-ui-ingress-tls
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -45,7 +45,7 @@ ui:
   # 'enabled' will deploy the S3GW user interface if set to `true`.
   enabled: true
   # 'serviceName' is the service name of the S3GW user interface.
-  serviceName: "s3gw-ui"
+  serviceName: ""
   # 'publicDomain' is the public domain of the UI Service used by the Ingress.
   publicDomain: ""
 
@@ -56,13 +56,13 @@ ui:
 # S3 Service
 #
 # 'serviceName' is the service name of S3GW.
-serviceName: "s3gw"
+serviceName: ""
 # 'useExistingSecret' use an existing secret containing the S3 credentials
 # for the default user
 useExistingSecret: false
 # 'defaultUserCredentialsSecret' the name of the secret containing
 # the S3 Access Key and the S3 Secret Key for the default user.
-defaultUserCredentialsSecret: "s3gw-creds"
+defaultUserCredentialsSecret: ""
 # 'accessKey' is the S3 Access Key; the value is used when
 # `useExistingSecret: false`.
 # Set this as the empty string to make the Chart to compute a random
@@ -84,7 +84,7 @@ privateDomain: "svc.cluster.local"
 # will be created. This assumes the Longhorn storage driver is installed.
 storageSize: 10Gi
 storageClass:
-  name: "longhorn-single"
+  name:
   create: true
 # For testing only:
 #  local: false


### PR DESCRIPTION
It is possible to deploy multiple default installations. 
It is only required to specify different release names.

Fixes: https://github.com/aquarist-labs/s3gw/issues/491
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
