### PR TITLE
fix regression for default storage class

### DIFF
--- a/charts/s3gw/templates/_helpers.tpl
+++ b/charts/s3gw/templates/_helpers.tpl
@@ -112,15 +112,6 @@ Default Access Credentials
 {{- end }}
 
 {{/*
-Default storage class name
-*/}}
-{{- define "s3gw.storageClassName" -}}
-{{- $dscn := printf "%s-%s-longhorn-single" .Release.Name .Release.Namespace }}
-{{- $name := default $dscn .Values.storageClass.name }}
-{{- $name }}
-{{- end }}
-
-{{/*
 Default backend service name
 */}}
 {{- define "s3gw.serviceName" -}}

--- a/charts/s3gw/templates/storage.yaml
+++ b/charts/s3gw/templates/storage.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
 spec:
-  storageClassName: {{ include "s3gw.storageClassName" . }}
+  storageClassName: {{ .Values.storageClass.name }}
   accessModes:
     - ReadWriteOnce
   resources:
@@ -18,7 +18,7 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ include "s3gw.storageClassName" . }}
+  name: {{ .Values.storageClass.name }}
   labels:
 {{ include "s3gw.labels" . | indent 4 }}
 volumeBindingMode: Immediate
@@ -44,7 +44,7 @@ metadata:
 {{ include "s3gw.labels" . | indent 4 }}
     type: local
 spec:
-  storageClassName: {{ include "s3gw.storageClassName" . }}
+  storageClassName: {{ .Values.storageClass.name }}
   capacity:
     storage: {{ .Values.storageSize }}
   accessModes:

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -82,10 +82,15 @@ privateDomain: "svc.cluster.local"
 # Backing storage.
 # Name the storage class to use. If create is true, an opinionated storage class
 # will be created. This assumes the Longhorn storage driver is installed.
+#
+# By specifying storageClass.name = "" and storageClass.create = false the chart
+# uses the cluster's default storage class.
+# This is the chart's default behavior.
+#
 storageSize: 10Gi
 storageClass:
   name:
-  create: true
+  create: false
 # For testing only:
 #  local: false
 #  localPath: /var/lib/local-storage


### PR DESCRIPTION
Cluster's default storage class can be specified with this combination of settings:

```
storageClass.create=false
storageClass.name=""
```

Note that this has always been the way the default storage class could be specified with the s3gw helm chart; the PR is restoring this behavior.

This mode now becomes the default for the charts.

Fixes: https://github.com/aquarist-labs/s3gw/issues/493
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
