### PR TITLE
fix unsupported protocol scheme issue when COSI driver connects to rgw

### DIFF
--- a/charts/s3gw/templates/_helpers.tpl
+++ b/charts/s3gw/templates/_helpers.tpl
@@ -229,3 +229,13 @@ COSI cluster role binding name
 {{- $name := $dcrn }}
 {{- $name }}
 {{- end }}
+
+{{/*
+COSI endpoint
+*/}}
+{{- define "s3gw-cosi.endpoint" -}}
+{{- $sn := include "s3gw.serviceName" . }}
+{{- $defaultendpoint := printf "http://%s.%s.%s" $sn .Release.Namespace .Values.privateDomain}}
+{{- $endpoint := default $defaultendpoint .Values.cosi.driver.endpoint }}
+{{- $endpoint }}
+{{- end }}

--- a/charts/s3gw/templates/cosi-driver-secret.yaml
+++ b/charts/s3gw/templates/cosi-driver-secret.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 stringData:
   DRIVERNAME: {{ include "s3gw-cosi.driverName" . }}
-  ENDPOINT: {{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
+  ENDPOINT: {{ include "s3gw-cosi.endpoint" . }}
   ACCESSKEY: {{ .Values.accessKey }}
   SECRETKEY: {{ .Values.secretKey }}
 {{- end }}

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -198,6 +198,9 @@ rgwCustomEnvs: []
 #  - cosi.driver.name: it specifies the name of the COSI driver.
 #                      Default: {Release.Name}.{Release.Namespace}.objectstorage.k8s.io
 #
+#  - cosi.driver.endpoint: it specifies the S3 endpoint url used by the COSI driver.
+#                          Default: {Release.Name}.{Release.Namespace}.{Values.privateDomain}
+#
 #  - cosi.sidecar.imageName: it specifies a custom image name for the COSI sidecar.
 #                            Default: s3gw-cosi-sidecar
 #
@@ -223,6 +226,7 @@ cosi:
     imageRegistry:
     imagePullPolicy:
     name:
+    endpoint:
 
   sidecar:
     imageName:


### PR DESCRIPTION
Added chart option:

- cosi.driver.endpoint: it specifies the S3 endpoint url used by the COSI driver.
Default: {Release.Name}.{Release.Namespace}.{Values.privateDomain}

The field's value defaults with the 'http://' protocol scheme, eg: http://s3gw.s3gw.svc.cluster.local

Fixes: https://github.com/aquarist-labs/s3gw/issues/511

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
