### PR TITLE
ci: upgrade Kind version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
           version: v3.6.0
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1
 
       - name: Run chart-testing (lint)
         run: |
@@ -57,7 +57,7 @@ jobs:
           version: v3.10.0
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1
 
       - name: Install cert-manager
         run: |


### PR DESCRIPTION
Upgrade Kind version and let it track the latest of th v1.x.y release series. This should avoid trouble with pinning the Kind version to something that only supports a very old version of the Kubernetes API

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
