### PR TITLE
chart: update logo and source URLs

### DIFF
--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -11,12 +11,14 @@ keywords:
   - storage
   - s3
 home: https://github.com/aquarist-labs/s3gw
-icon: |-
-  https://raw.githubusercontent.com/aquarist-labs/aquarium-website/gh-pages/images/logo-xl.png
+icon: https://s3gw.io/img/logo-xl.png
 sources:
   - https://github.com/aquarist-labs/s3gw-charts
   - https://github.com/aquarist-labs/s3gw
   - https://github.com/aquarist-labs/ceph
+  - https://github.com/aquarist-labs/s3gw-ui
+  - https://github.com/aquarist-labs/s3gw-cosi-driver
+  - https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar
 maintainers:
   - name: s3gw maintainers
     email: s3gw@suse.com


### PR DESCRIPTION
Update the logo with a URL from the new website.
With the website re-design, the old logo URL is no longer available. This URL is used in app catalogues like artifacthub.io.

Mention additional repos in the sources list.
This completes the list of source repositories of the software that is installed when using this chart.

Fixes: aquarist-labs/s3gw#570

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
