### PR TITLE
chart: validate email for tls issuer

### DIFF
--- a/charts/s3gw/templates/chart-validation.yaml
+++ b/charts/s3gw/templates/chart-validation.yaml
@@ -9,3 +9,11 @@
 {{- if (and .Values.useExistingSecret (empty .Values.defaultUserCredentialsSecret)) }}
 {{- fail "Please provide a secret name for `.Values.defaultUserCredentialSecret`" }}
 {{- end }}
+
+{{- if .Values.useCertManager }}
+{{- if eq .Values.tlsIssuer "s3gw-letsencrypt-issuer" }}
+{{- if eq .Values.email "mail@example.com" }}
+{{- fail "Please provide a valid email for letsencrypt" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/s3gw/templates/tls-issuer.yaml
+++ b/charts/s3gw/templates/tls-issuer.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.useCertManager }}
+{{- if eq .Values.tlsIssuer "s3gw-issuer" }}
 ---
 # Self-signed issuer
 apiVersion: cert-manager.io/v1
@@ -20,6 +21,7 @@ metadata:
 spec:
   ca:
     secretName: {{ .Release.Name }}-{{ .Release.Namespace }}-ca-root
+{{- else if eq .Values.tlsIssuer "s3gw-letsencrypt-issuer" }}
 ---
 # Let's encrypt production issuer
 apiVersion: cert-manager.io/v1
@@ -43,4 +45,5 @@ spec:
               annotations:
                 traefik.ingress.kubernetes.io/router.entrypoints: websecure
                 traefik.ingress.kubernetes.io/router.tls: "true"
+{{- end }}
 {{- end }}


### PR DESCRIPTION
When using the Letsencrypt TLS issuer, a valid email address (the one of the account requesting the certificate) is required in the .email field of the values.yaml.
This change introduces a templating check that fails the installation of the s3gw if the letsencrypt issuer is to be used with the default (invalid) email, reminding the user to set a valid one. It also avoids deploying both the self-signed and letsencrypt issuers at the same time. In case the self-signed issuer is desired it unnecessary to deploy the letsencrypt issuer as well and with no valid email given (which isn't necessary for the self signed issuer), the letsencrypt issued would not deploy successfully.

Fixes: aquarist-labs/s3gw#596

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
