### PR TITLE
fix installation failure when publicDomain is empty

### DIFF
--- a/charts/s3gw/templates/chart-validation.yaml
+++ b/charts/s3gw/templates/chart-validation.yaml
@@ -1,4 +1,4 @@
-{{- if (empty .Values.publicDomain) }}
+{{- if (and .Values.ingress.enabled (empty .Values.publicDomain)) }}
 {{- fail "Please provide a value for `.Values.publicDomain`." }}
 {{- end }}
 


### PR DESCRIPTION
When publicDomain field is empty charts intallation must fail only if ingress.enabled = true.
When ingress.enabled = false, publicDomain field is ignored.

Fixes: https://github.com/aquarist-labs/s3gw/issues/602

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
