### PR TITLE
fix: use generated key pair for COSI

### DIFF
--- a/charts/s3gw/templates/cosi-driver-secret.yaml
+++ b/charts/s3gw/templates/cosi-driver-secret.yaml
@@ -11,6 +11,6 @@ type: Opaque
 stringData:
   DRIVERNAME: {{ include "s3gw-cosi.driverName" . }}
   ENDPOINT: {{ include "s3gw-cosi.endpoint" . }}
-  ACCESSKEY: {{ .Values.accessKey }}
-  SECRETKEY: {{ .Values.secretKey }}
+  ACCESSKEY: {{ include "s3gw.defaultAccessKey" . }}
+  SECRETKEY: {{ include "s3gw.defaultSecretKey" . }}
 {{- end }}

--- a/charts/s3gw/tests/cosi_test.yaml
+++ b/charts/s3gw/tests/cosi_test.yaml
@@ -1,0 +1,70 @@
+---
+#
+suite: COSI
+templates:
+  - cosi-driver-secret.yaml
+tests:
+
+  - it: Don't generate manifest when COSI is disabled
+    set:
+      cosi.enabled: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
+        templates:
+          - cosi-driver-secret.yaml
+
+  - it: Generate COSI secret when COSI is enabled
+    set:
+      cosi.enabled: true
+    asserts:
+
+      - hasDocuments:
+          count: 1
+        templates:
+          - cosi-driver-secret.yaml
+
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+        templates:
+          - cosi-driver-secret.yaml
+
+  - it: COSI secret contains expected values when keys are given
+    set:
+      cosi.enabled: true
+      accessKey: foo
+      secretKey: bar
+    asserts:
+
+      - equal:
+          path: stringData.ACCESSKEY
+          value: foo
+        templates:
+          - cosi-driver-secret.yaml
+
+      - equal:
+          path: stringData.SECRETKEY
+          value: bar
+        templates:
+          - cosi-driver-secret.yaml
+
+  - it: COSI secret contains expected values when keys are generated
+    set:
+      cosi.enabled: true
+      accessKey: null
+      secretKey: null
+    asserts:
+
+      - matchRegex:
+          path: stringData.ACCESSKEY
+          pattern: ^[a-zA-Z0-9]+$
+        templates:
+          - cosi-driver-secret.yaml
+
+      - matchRegex:
+          path: stringData.SECRETKEY
+          pattern: ^[a-zA-Z0-9]+$
+        templates:
+          - cosi-driver-secret.yaml


### PR DESCRIPTION
- Use the generated secret/access key pair in the COSI driver secret, when no keys are explicitly given.
- Add tests ensuring the correct generation of the manifest for the COSI driver secret.

# Describe your changes

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
