### PR TITLE
charts/configmap: add S3GW_SERVICE_URL

### DIFF
--- a/charts/s3gw/templates/configmap.yaml
+++ b/charts/s3gw/templates/configmap.yaml
@@ -9,8 +9,8 @@ metadata:
 data:
 {{- if .Values.ui.enabled }}
 {{- if or .Values.useCertManager .Values.tls.publicDomain.crt }}
-  RGW_SERVICE_URL: 'https://{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
+  S3GW_SERVICE_URL: 'https://{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
 {{- else}}
-  RGW_SERVICE_URL: 'http://{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
+  S3GW_SERVICE_URL: 'http://{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Adds a new configmap entry, pointing to the address of the s3gw service.

This will be consumed by the `s3gw-ui` backend.

We are leaving the original entry in there nonetheless so we don't break the UI if/when this gets merged, depending on whether changed to the UI get merged before or after. It should be removed in a coming release.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>