### PR TITLE
charts/ui: allow setting custom registry

### DIFF
--- a/charts/s3gw/templates/_helpers.tpl
+++ b/charts/s3gw/templates/_helpers.tpl
@@ -87,7 +87,7 @@ Version helpers for the image tag
 {{- define "s3gw-ui.image" -}}
 {{- $tag := default (printf "v%s" .Chart.Version) .Values.ui.imageTag }}
 {{- $name := default "s3gw/s3gw-ui" .Values.ui.imageName }}
-{{- $registry := default "quay.io" .Values.imageRegistry }}
+{{- $registry := default "quay.io" .Values.ui.imageRegistry }}
 {{- printf "%s/%s:%s" $registry $name $tag }}
 {{- end }}
 


### PR DESCRIPTION
We were relying on the custom registry value used for s3gw, but we may want to use a different one.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>
