### PR TITLE
ci: Run `helm unittest` in strict mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,6 @@ jobs:
             --charts charts/s3gw \
             --target-branch ${GITHUB_REF_NAME} \
             --helm-extra-args="--timeout=500s" \
-            --additional-commands="helm unittest charts/s3gw" \
+            --additional-commands="helm unittest --strict charts/s3gw" \
             --validate-maintainers=false \
             --debug

--- a/charts/s3gw/templates/chart-validation.yaml
+++ b/charts/s3gw/templates/chart-validation.yaml
@@ -2,12 +2,12 @@
 {{- fail "Please provide a value for `.Values.publicDomain`." }}
 {{- end }}
 
-{{- if (and .Values.ui.enabled (empty .Values.ui.publicDomain)) }}
+{{- if (and .Values.ingress.enabled (and .Values.ui.enabled (empty .Values.ui.publicDomain))) }}
 {{- fail "Please provide a value for `.Values.ui.publicDomain`." }}
 {{- end }}
 
 {{- if (and .Values.useExistingSecret (empty .Values.defaultUserCredentialsSecret)) }}
-{{- fail "Please provide a secret name for `.Values.defaultUserCredentialSecret`" }}
+{{- fail "Please provide a secret name for `.Values.defaultUserCredentialsSecret`" }}
 {{- end }}
 
 {{- if .Values.useCertManager }}

--- a/charts/s3gw/tests/credentials_test.yaml
+++ b/charts/s3gw/tests/credentials_test.yaml
@@ -2,6 +2,9 @@
 suite: Secrets
 templates:
   - secret.yaml
+release:
+  name: s3gw-release
+  namespace: s3gw-system
 tests:
 
   - it: Setting Access Keys
@@ -9,12 +12,32 @@ tests:
       accessKey: foo
       secretKey: bar
       useExistingSecret: false
-    assert:
+    asserts:
+
+      - hasDocuments:
+          count: 1
+        templates:
+          - secret.yaml
+
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: s3gw-release-s3gw-system-creds
+          namespace: s3gw-system
+        documentIndex: 0
+        templates:
+          - secret.yaml
+
       - equal:
-          path: stringData.RGW_DEFAULT_USER_ACCESSS_KEY
+          path: stringData.RGW_DEFAULT_USER_ACCESS_KEY
           value: foo
         documentIndex: 0
+        templates:
+          - secret.yaml
+
       - equal:
           path: stringData.RGW_DEFAULT_USER_SECRET_KEY
           value: bar
         documentIndex: 0
+        templates:
+          - secret.yaml

--- a/charts/s3gw/tests/deployment_test.yaml
+++ b/charts/s3gw/tests/deployment_test.yaml
@@ -2,29 +2,16 @@
 suite: Deployment
 templates:
   - deployment.yaml
+release:
+  name: s3gw
+  namespace: s3gw-system
 tests:
 
   - it: Always deploys s3gw by default
     release:
       name: s3gw-release
       namespace: s3gw-namespace
-    assert:
-      - containsDocument:
-          kind: Deployment
-          apiVersion: apps/v1
-          name: s3gw-release
-          namespace: s3gw-namespace
-
-  - it: Deploys s3gw and s3gw UI
-    set:
-      ui.enabled: true
-    release:
-      name: s3gw-release-ui
-      namespace: s3gw-namespace
-    assert:
-
-      - hasDocuments:
-          count: 2
+    asserts:
 
       - containsDocument:
           kind: Deployment
@@ -32,21 +19,45 @@ tests:
           name: s3gw-release
           namespace: s3gw-namespace
         documentIndex: 0
+        templates:
+          - deployment.yaml
+
+  - it: Deploys s3gw and s3gw UI
+    set:
+      ui.enabled: true
+    release:
+      name: s3gw-release-ui
+      namespace: s3gw-namespace
+    asserts:
+
+      - hasDocuments:
+          count: 2
 
       - containsDocument:
           kind: Deployment
           apiVersion: apps/v1
           name: s3gw-release-ui
           namespace: s3gw-namespace
+        documentIndex: 0
+        templates:
+          - deployment.yaml
+
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: s3gw-release-ui-ui
+          namespace: s3gw-namespace
         documentIndex: 1
+        templates:
+          - deployment.yaml
 
   - it: Deploys s3gw only
     set:
       ui.enabled: false
     release:
-      name: s3gw-release-ui
+      name: s3gw-release
       namespace: s3gw-namespace
-    assert:
+    asserts:
 
       - hasDocuments:
           count: 1
@@ -56,3 +67,6 @@ tests:
           apiVersion: apps/v1
           name: s3gw-release
           namespace: s3gw-namespace
+        documentIndex: 0
+        templates:
+          - deployment.yaml

--- a/charts/s3gw/tests/validation_test.yaml
+++ b/charts/s3gw/tests/validation_test.yaml
@@ -5,13 +5,19 @@
 suite: Validation
 templates:
   - chart-validation.yaml
+release:
+  name: s3gw
+  namespace: s3gw-system
 tests:
 
   - it: Fail templating if ingress is enabled without publicDomain
     set:
       ingress.enabled: true
       publicDomain: null
-    assert:
+      ui.enabled: false
+      useExistingSecret: false
+      useCertManager: false
+    asserts:
       - failedTemplate:
           errorMessage: "Please provide a value for `.Values.publicDomain`."
 
@@ -19,22 +25,37 @@ tests:
     set:
       ingress.enabled: true
       publicDomain: "example.com"
-    assert:
-      - notFailedTemplate: {}
+      ui.enabled: false
+      useExistingSecret: false
+      useCertManager: false
+    asserts:
+      # An empty document counts as having failed templating. But in case of
+      # chart-validation.yaml we expect the document to be empty if none of the
+      # checks fail.
+      - hasDocuments:
+          count: 0
 
   - it: Don't fail if without publicDomain if ingress is disabled
     set:
       ingress.enabled: false
       publicDomain: null
-    assert:
-      - notFailedTemplate: {}
+      useExistingSecret: false
+      useCertManager: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
 
   # - - -
   - it: Fail templating if UI is enabled without a ui.publicDomain
     set:
       ui.enabled: true
       ui.publicDomain: null
-    assert:
+      publicDomain: example.com
+      useExistingSecret: false
+      useCertManager: false
+    asserts:
+
       - failedTemplate:
           errorMessage: "Please provide a value for `.Values.ui.publicDomain`."
 
@@ -42,45 +63,71 @@ tests:
     set:
       ui.enabled: true
       ui.publicDomain: "example.com"
-    assert:
-      - notFailedTemplate: {}
+      publicDomain: "example.com"
+      useExistingSecret: false
+      useCertManager: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
 
   - it: Don't fail if UI is disabled and doesn't have a ui.publicDomain
     set:
       ui.enabled: false
       ui.publicDomain: null
-    assert:
-      - notFailedTemplate: {}
+      publicDomain: example.com
+      useExistingSecret: false
+      useCertManager: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
 
   # - - -
   - it: Fail templating when using existing secret by no secret is given
     set:
       useExistingSecret: true
-      defaultUserCredentialSecert: null
-    assert:
+      defaultUserCredentialsSecret: null
+      ingress.enabled: false
+      useCertManager: false
+    asserts:
+
       - failedTemplate:
-          errorMessage: "Please provide a secret name for `.Values.defaultUserCredentialSecret`"
+          errorMessage: "Please provide a secret name for `.Values.defaultUserCredentialsSecret`"
 
   - it: Don't fail when not using an existing secret
     set:
       useExistingSecret: false
-      defaultUserCredentialSecert: null
-    assert:
-      - notFailedTemplate: {}
+      defaultUserCredentialsSecret: null
+      ingress.enabled: false
+      useCertManager: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
 
   - it: Don't fail when a secret name is given
     set:
       useExistingSecret: true
-      defaultUserCredentialSecert: "my-super-secret"
-    assert:
-      - notFailedTemplate: {}
+      defaultUserCredentialsSecret: "my-super-secret"
+      ingress.enabled: false
+      useCertManager: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
 
   # - - -
   - it: Fail templating with default email and letsencrypt issuer
     set:
       useCertManager: true
       tlsIssuer: "s3gw-letsencrypt-issuer"
-    assert:
+      ingress.enabled: true
+      publicDomain: "example.com"
+      ui.enabled: false
+      useExistingSecret: false
+    asserts:
+
       - failedTemplate:
           errorMessage: "Please provide a valid email for letsencrypt"
 
@@ -88,20 +135,38 @@ tests:
     set:
       useCertManager: true
       tlsIssuer: "s3gw-issuer"
-    assert:
-      - notFailedTemplate: {}
+      ingress.enabled: true
+      publicDomain: "example.com"
+      ui.enabled: false
+      useExistingSecret: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
 
   - it: Don't fail with valid email and letsencrypt issuer
     set:
       useCertManager: true
       tlsIssuer: "s3gw-letsencrypt-issuer"
       email: "someone@emailprovider.com"
-    assert:
-      - notFailedTemplate: {}
+      ingress.enabled: true
+      publicDomain: "example.com"
+      ui.enabled: false
+      useExistingSecret: false
+    asserts:
+
+      - hasDocuments:
+          count: 0
 
   - it: Don't fail with default email when not using cert-manager
     set:
       useCertManager: false
       tlsIssuer: "s3gw-letsencrypt-issuer"
-    assert:
-      - notFailedTemplate: {}
+      ingress.enabled: true
+      publicDomain: "example.com"
+      ui.enabled: false
+      useExistingSecret: false
+    asserts:
+
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
Enable the `--strict` command line option for the Helm Unittest plugin. This option causes the unittest suites to be evaluated against their schema and potential typos are considered failures. Otherwise typos in the test suites may cause tests to be silently ignored or other silent behavior change without necessarily causing a failure.
See: https://github.com/helm-unittest/helm-unittest/issues/178

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
