### PR TITLE
Fix installation fails when using Let's Encrypt cluster issuer

### DIFF
--- a/charts/s3gw/templates/certificate.yaml
+++ b/charts/s3gw/templates/certificate.yaml
@@ -33,6 +33,6 @@ spec:
     - '*.{{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}'
   issuerRef:
     kind: ClusterIssuer
-    name: {{ .Release.Name }}-{{ .Release.Namespace }}-issuer
+    name: {{ .Release.Name }}-{{ .Release.Namespace }}-s3gw-issuer
   secretName: {{ .Release.Name }}-{{ .Release.Namespace }}-cluster-ip-tls
 {{- end }}

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -12,7 +12,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares:
       '{{ .Release.Namespace }}-{{ include "s3gw.CORSMiddlewareName" . }}@kubernetescrd'
-    cert-manager.io/cluster-issuer: {{ default .Values.tlsIssuer .Values.customTlsIssuer | quote }}
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-{{ .Release.Namespace }}-{{ .Values.tlsIssuer }}
 spec:
   tls:
     - hosts:
@@ -88,7 +88,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares:
       '{{ .Release.Namespace }}-{{ include "s3gw.CORSMiddlewareName" . }}@kubernetescrd'
-    cert-manager.io/cluster-issuer: {{ default .Values.tlsIssuer .Values.customTlsIssuer | quote }}
+    cert-manager.io/cluster-issuer: {{ .Release.Name }}-{{ .Release.Namespace }}-{{ .Values.tlsIssuer }}
 spec:
   tls:
     - hosts:

--- a/charts/s3gw/templates/ingress-traefik.yaml
+++ b/charts/s3gw/templates/ingress-traefik.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
     - hosts:
         - '{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
-        - '*.{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
+#        - '*.{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'
       secretName: s3gw-ingress-tls
   rules:
     - host: '{{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }}'

--- a/charts/s3gw/templates/tls-issuer.yaml
+++ b/charts/s3gw/templates/tls-issuer.yaml
@@ -40,10 +40,6 @@ spec:
     solvers:
     - http01:
         ingress:
-          ingressTemplate:
-            metadata:
-              annotations:
-                traefik.ingress.kubernetes.io/router.entrypoints: websecure
-                traefik.ingress.kubernetes.io/router.tls: "true"
+          ingressClassName: traefik
 {{- end }}
 {{- end }}

--- a/charts/s3gw/templates/tls-issuer.yaml
+++ b/charts/s3gw/templates/tls-issuer.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.useCertManager }}
-{{- if eq .Values.tlsIssuer "s3gw-issuer" }}
 ---
 # Self-signed issuer
 apiVersion: cert-manager.io/v1
@@ -15,19 +14,20 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ .Release.Name }}-{{ .Release.Namespace }}-issuer
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-s3gw-issuer
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 spec:
   ca:
     secretName: {{ .Release.Name }}-{{ .Release.Namespace }}-ca-root
-{{- else if eq .Values.tlsIssuer "s3gw-letsencrypt-issuer" }}
+
+{{- if eq .Values.tlsIssuer "s3gw-letsencrypt-issuer" }}
 ---
 # Let's encrypt production issuer
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ .Release.Name }}-{{ .Release.Namespace }}-letsencrypt-issuer
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-s3gw-letsencrypt-issuer
   labels:
 {{ include "s3gw.labels" . | indent 4}}
 spec:


### PR DESCRIPTION
# Describe your changes
This PR fixes 3 bugs described in each commits:
* Fix tlsIssuer names and the consumers of these tlsIssuers
* The ingress of AMCE server need to be contact through http port
* Cannot use wildcard for http01 AMCE resolver

## Issue ticket number and link
* https://github.com/aquarist-labs/s3gw/issues/671
* https://github.com/aquarist-labs/s3gw/issues/655

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
