### PR TITLE
charts/deployment: adjust for wrapper script and release v0.23.0

### DIFF
--- a/charts/s3gw/Chart.yaml
+++ b/charts/s3gw/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: s3gw
-version: 0.22.0
+version: 0.23.0
 kubeVersion: ">=1.14"
 description: |
   Easy-to-use Open Source and Cloud Native S3 service for use on Rancher's

--- a/charts/s3gw/questions.yaml
+++ b/charts/s3gw/questions.yaml
@@ -251,7 +251,6 @@ questions:
     group: "Advanced"
     show_subquestion_if: true
     subquestions:
-
       - variable: imageRegistry
         default:
         description: "Image Registry"
@@ -329,8 +328,8 @@ questions:
     group: "Advanced"
 
   - variable: logLevel
-    default: "1"
-    description: "s3gw pod log level, lower values are less verbose"
+    default: "none"
+    description: "s3gw pod log level, allowed values: 'none', 'low', 'medium', 'high'"
     label: "s3gw pod log level"
     required: false
     type: string
@@ -345,7 +344,6 @@ questions:
     group: "COSI"
     show_subquestion_if: true
     subquestions:
-
       - variable: cosi.driver.imageName
         default: ""
         description: "Image name for the COSI Driver"

--- a/charts/s3gw/templates/deployment.yaml
+++ b/charts/s3gw/templates/deployment.yaml
@@ -27,26 +27,22 @@ spec:
           image: {{ include "s3gw.image" . | quote }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy }}
           args:
-            - "--rgw-dns-name"
+            - "--dns-name"
 {{- if .Values.ingress.enabled }}
             - {{ include "s3gw.serviceName" . }}.{{ .Values.publicDomain }},
               {{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
 {{- else}}
             - {{ include "s3gw.serviceName" . }}.{{ .Release.Namespace }}.{{ .Values.privateDomain }}
 {{- end }}
-            - "--rgw-backend-store"
-            - sfs
-            - "--debug-rgw"
+            - "--debug"
             - '{{ .Values.logLevel }}'
-            - "--rgw_frontends"
 {{- if or .Values.useCertManager .Values.tls.publicDomain.crt }}
-            - "beast port=7480 ssl_port=7481
-                ssl_certificate=/s3gw-cluster-ip-tls/tls.crt
-                ssl_private_key=/s3gw-cluster-ip-tls/tls.key"
-{{ else }}
-            - "beast port=7480"
+            - "--cert"
+            - "/s3gw-cluster-ip-tls/tls.crt"
+            - "/s3gw-cluster-ip-tls/tls.key"
 {{ end }}
 {{- range $.Values.rgwCustomArgs }}
+            - "--"
             - {{ . | quote}}
 {{- end }}
           env:

--- a/charts/s3gw/values.yaml
+++ b/charts/s3gw/values.yaml
@@ -108,9 +108,9 @@ storageClass:
 #   email: foobar@suse.com
 
 # s3gw pod log level.
-# Valid values are positive integers starting from 0.
+# Valid values are "none", "low", "medium", and "high".
 # Higher values are more verbose.
-logLevel: "1"
+logLevel: "none"
 
 # --- Advanced Configuration ---
 


### PR DESCRIPTION
By using a wrapper script as the container entrypoint, we abstract how arguments to the underlying radosgw binary are passed. Instead, pass arguments known by the script, and let it do what is best.

This pull request has a companion pull request in aquarist-labs/s3gw#758 .

Also, this patchset also releases v0.23.0.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>