### PR TITLE
Several improvements to the chart

### DIFF
--- a/charts/s3gw/templates/NOTES.txt
+++ b/charts/s3gw/templates/NOTES.txt
@@ -2,11 +2,11 @@ Thank you for installing {{ .Chart.Name }} {{ printf "v%s" .Chart.Version }}
 
 The S3 endpoint is available at:
 
-{{ printf "%s.%s" (include "s3gw.serviceName" .) .Values.publicDomain | indent 4 }}
+{{ printf "https://%s.%s" (include "s3gw.serviceName" .) .Values.publicDomain | indent 4 }}
 {{ if .Values.ui.enabled}}
 and the web interface is available at:
 
-{{ printf "%s.%s" (include "s3gw.uiServiceName" .) .Values.ui.publicDomain | indent 4 }}
+{{ printf "https://%s.%s" (include "s3gw.uiServiceName" .) .Values.ui.publicDomain | indent 4 }}
 {{- end }}
 {{ if and (not .Values.useExistingSecret) (empty .Values.accessKey) }}
 An access key has been generated: {{ include "s3gw.defaultAccessKey" . | quote }}

--- a/charts/s3gw/templates/chart-validation.yaml
+++ b/charts/s3gw/templates/chart-validation.yaml
@@ -17,3 +17,15 @@
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if (and .Values.ingress.enabled (not .Values.useCertManager)) }}
+{{- if (or (empty .Values.tls.publicDomain.crt) (empty .Values.tls.publicDomain.key)) }}
+{{- fail "Please provide valid values for `.Values.tls.publicDomain`" }}
+{{- end }}
+{{- if (or (empty .Values.tls.privateDomain.crt) (empty .Values.tls.privateDomain.key)) }}
+{{- fail "Please provide valid values for `.Values.tls.privateDomain`" }}
+{{- end }}
+{{- if (and .Values.ui.enabled (or (empty .Values.tls.ui.publicDomain.crt) (empty .Values.tls.ui.publicDomain.key))) }}
+{{- fail "Please provide valid values for `.Values.tls.ui.publicDomain`" }}
+{{- end }}
+{{- end }}

--- a/charts/s3gw/tests/validation_test.yaml
+++ b/charts/s3gw/tests/validation_test.yaml
@@ -28,6 +28,10 @@ tests:
       ui.enabled: false
       useExistingSecret: false
       useCertManager: false
+      tls.publicDomain.crt: foo
+      tls.publicDomain.key: bar
+      tls.privateDomain.crt: abc
+      tls.privateDomain.key: xyz
     asserts:
       # An empty document counts as having failed templating. But in case of
       # chart-validation.yaml we expect the document to be empty if none of the
@@ -66,6 +70,12 @@ tests:
       publicDomain: "example.com"
       useExistingSecret: false
       useCertManager: false
+      tls.publicDomain.crt: foo
+      tls.publicDomain.key: bar
+      tls.privateDomain.crt: abc
+      tls.privateDomain.key: xyz
+      tls.ui.publicDomain.crt: aaa
+      tls.ui.publicDomain.key: bbb
     asserts:
 
       - hasDocuments:
@@ -78,6 +88,10 @@ tests:
       publicDomain: example.com
       useExistingSecret: false
       useCertManager: false
+      tls.publicDomain.crt: foo
+      tls.publicDomain.key: bar
+      tls.privateDomain.crt: abc
+      tls.privateDomain.key: xyz
     asserts:
 
       - hasDocuments:
@@ -166,6 +180,10 @@ tests:
       publicDomain: "example.com"
       ui.enabled: false
       useExistingSecret: false
+      tls.publicDomain.crt: foo
+      tls.publicDomain.key: bar
+      tls.privateDomain.crt: abc
+      tls.privateDomain.key: xyz
     asserts:
 
       - hasDocuments:


### PR DESCRIPTION
- Append the https:// protocol to the displayed URLs. Since the chart always installs the TLS certificates, we can restrict the output URLs to HTTPS.
- Add more chart validation tests.
