### PR TITLE
[dnm] workflows/test: use 'dev-latest' s3gw image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,7 @@ jobs:
             --charts charts/s3gw \
             --target-branch ${GITHUB_REF_NAME} \
             --helm-extra-args="--timeout=500s" \
+            --helm-extra-set-args="--set=imageTag=dev-latest" \
             --additional-commands="helm unittest --strict charts/s3gw" \
             --validate-maintainers=false \
             --debug


### PR DESCRIPTION
This patch set attempts to have tests running out of a `dev-latest` version of the s3gw container in quay[^1].

[^1]: which currently doesn't exist, nor gets built. Should this work, however, that would be the next step.